### PR TITLE
Rewrite MC-07 phase transition tutorial

### DIFF
--- a/content/en/tutorials/mcs/mc07.md
+++ b/content/en/tutorials/mcs/mc07.md
@@ -6,85 +6,87 @@ toc: true
 weight: 9
 ---
 
-## Introduction
+The goal of this tutorial is to learn how to detect a second-order phase transition from finite-size simulations, using the classic example of the two-dimensional Ising model.
+No true phase transition can occur on a finite system, but finite-size simulations show clear precursor signs that — combined with finite-size scaling — allow a precise determination of the critical temperature and the universality class of the transition.
 
-The goal of this tutorial is to learn how to detect a second-order phase transition from finite-size simulations, using the venerable example of the 2d Ising model. No true phase transition can occur on a finite system. Nevertheless finite-size simulations show clear precursor signs of the phase transition which, combined with finite-size scaling, allow a precise determination of the universality class of a continuous phase transition.
+Almost everything is known about the phase transition in the 2D Ising model since it is exactly solvable.
+Here we recover the location of the critical point and the critical exponents as if they were unknown, to illustrate the methods.
+Extracting precise estimates requires long simulations, so we start the fine-grid run in the background at the outset and analyse the coarse-grid run first.
 
-Almost everything is known about the phase transition in the 2d Ising model since it is exactly solvable. In this tutotial, we will try to recover the location of the critical point, as well as critical exponents as if we would not know them in order to illustrate the methods. To make precise estimations requires quite some time. For this let us start the final simulation parameters in the background while doing the first part of the tutorial.
+## Background simulations
 
-You can start the second simulation in the background with the parameter file <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-07-phase-transition/parm7b" download>`parm7b`</a> and type:
+Start the fine-grid simulations now so they run while you work through the rest of the tutorial.
+
+#### Setting up and running on the command line
+
+Download <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-07-phase-transition/parm7b" download>`parm7b`</a> and run:
 
 ```
 parameter2xml parm7b
-spinmc --Tmin 10  parm7b.in.xml &
+spinmc --Tmin 10 parm7b.in.xml &
 ```
-    
-or run the first part of <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-07-phase-transition/tutorial7b.py" download>`tutorial7b.py`</a>:
 
-```
+#### Setting up and running in Python
+
+The first part of <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-07-phase-transition/tutorial7b.py" download>`tutorial7b.py`</a> sets up and launches the same simulation:
+
+```Python
 import pyalps
 import matplotlib.pyplot as plt
 import pyalps.plot
 import numpy as np
 import pyalps.fit_wrapper as fw
-```
 
-### Prepare the input parameters 
-
-```
 parms = []
-for l in [32,48,64]:
+for l in [32, 48, 64]:
     for t in [2.24, 2.25, 2.26, 2.27, 2.28, 2.29, 2.30, 2.31, 2.32, 2.33, 2.34, 2.35]:
         parms.append(
-            { 
-            'LATTICE'        : "square lattice", 
-            'T'              : t,
-            'J'              : 1 ,
-            'THERMALIZATION' : 5000,
-            'SWEEPS'         : 150000,
-            'UPDATE'         : "cluster",
-            'MODEL'          : "Ising",
-            'L'              : l
-            }  
+            {
+                'LATTICE'        : "square lattice",
+                'T'              : t,
+                'J'              : 1,
+                'THERMALIZATION' : 5000,
+                'SWEEPS'         : 150000,
+                'UPDATE'         : "cluster",
+                'MODEL'          : "Ising",
+                'L'              : l
+            }
         )
+
+input_file = pyalps.writeInputFiles('parm7b', parms)
+pyalps.runApplication('spinmc', input_file, Tmin=5)
 ```
 
-### Write the input file and run the simulation
+## Rough scan: locating the phase transition
 
-```
-input_file = pyalps.writeInputFiles('parm7b',parms) 
-pyalps.runApplication('spinmc',input_file,Tmin=5)
-```
+We first make a coarse temperature scan on small systems to locate the critical region.
 
+#### Setting up and running on the command line
 
-## Locate roughly the phase transition
-
-First, we make a rough temperature scan on small systems, in order to locate roughly the critical range. We use the parameter file <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-07-phase-transition/parm7a" download>`parm7a`</a> and the command
+Download <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-07-phase-transition/parm7a" download>`parm7a`</a> and run:
 
 ```
 parameter2xml parm7a
 spinmc --Tmin 5 parm7a.in.xml
 ```
 
-Alternatively, we can run the simulations in Python with the file <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-07-phase-transition/tutorial7a.py" download>`tutorial7a.py`</a>:
+#### Setting up and running in Python
 
-```
+Using <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-07-phase-transition/tutorial7a.py" download>`tutorial7a.py`</a>:
+
+```Python
 import pyalps
 import matplotlib.pyplot as plt
 import pyalps.plot
-```
 
-#### Prepare the input parameters
-
-```
 parms = []
-for l in [4,8,16]: 
-    for t in [5.0,4.5,4.0,3.5,3.0,2.9,2.8,2.7]:
+for l in [4, 8, 16]:
+    for t in [5.0, 4.5, 4.0, 3.5, 3.0, 2.9, 2.8, 2.7]:
         parms.append(
-            { 
-                'LATTICE'        : "square lattice", 
+            {
+                'LATTICE'        : "square lattice",
                 'T'              : t,
-                'J'              : 1 ,
+                'J'              : 1,
                 'THERMALIZATION' : 1000,
                 'SWEEPS'         : 400000,
                 'UPDATE'         : "cluster",
@@ -94,10 +96,10 @@ for l in [4,8,16]:
         )
     for t in [2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.2]:
         parms.append(
-            { 
-                'LATTICE'        : "square lattice", 
+            {
+                'LATTICE'        : "square lattice",
                 'T'              : t,
-                'J'              : 1 ,
+                'J'              : 1,
                 'THERMALIZATION' : 1000,
                 'SWEEPS'         : 40000,
                 'UPDATE'         : "cluster",
@@ -105,44 +107,43 @@ for l in [4,8,16]:
                 'L'              : l
             }
         )
+
+input_file = pyalps.writeInputFiles('parm7a', parms)
+pyalps.runApplication('spinmc', input_file, Tmin=5)
 ```
 
-#### Write the input file and run the simulation
+### Magnetization, susceptibility, and specific heat
 
-```
-input_file = pyalps.writeInputFiles('parm7a',parms)
-pyalps.runApplication('spinmc',input_file,Tmin=5)
-```
+The order parameter of the Ising transition is the magnetization per site $m$.
+On a finite system $\langle m \rangle = 0$ by symmetry, so we plot the average absolute value $\langle |m| \rangle$ instead.
+Load the results and plot it:
 
-### Magnetization, susceptibility and specific heat
-
-The order parameter describing the low-temperature phase in the Ising model is the magnetization per site $m$. Of course, on a finite-system, $\langle m\rangle$ is zero by symmetry since there is no true symmetry breaking, and one should rather look at the average absolute value of magnetization per site. In order to evaluate the data and load the observables we want to run the following lines of Python:
-
-```
+```Python
 pyalps.evaluateSpinMC(pyalps.getResultFiles(prefix='parm7a'))
-data = pyalps.loadMeasurements(pyalps.getResultFiles(prefix='parm7a'),['|Magnetization|', 'Connected Susceptibility', 'Specific Heat', 'Binder Cumulant', 'Binder Cumulant U2'])
-magnetization_abs = pyalps.collectXY(data,x='T',y='|Magnetization|',foreach=['L'])
-connected_susc = pyalps.collectXY(data,x='T',y='Connected Susceptibility',foreach=['L'])
-spec_heat = pyalps.collectXY(data,x='T',y='Specific Heat',foreach=['L'])
-binder_u4 = pyalps.collectXY(data,x='T',y='Binder Cumulant',foreach=['L'])
-binder_u2 = pyalps.collectXY(data,x='T',y='Binder Cumulant U2',foreach=['L'])
-```
+data = pyalps.loadMeasurements(
+    pyalps.getResultFiles(prefix='parm7a'),
+    ['|Magnetization|', 'Connected Susceptibility', 'Specific Heat', 'Binder Cumulant', 'Binder Cumulant U2']
+)
+magnetization_abs = pyalps.collectXY(data, x='T', y='|Magnetization|',          foreach=['L'])
+connected_susc    = pyalps.collectXY(data, x='T', y='Connected Susceptibility',  foreach=['L'])
+spec_heat         = pyalps.collectXY(data, x='T', y='Specific Heat',             foreach=['L'])
+binder_u4         = pyalps.collectXY(data, x='T', y='Binder Cumulant',           foreach=['L'])
+binder_u2         = pyalps.collectXY(data, x='T', y='Binder Cumulant U2',        foreach=['L'])
 
-and make a plot of the |Magnetization| versus $T$:
-
-```
 plt.figure()
 pyalps.plot.plot(magnetization_abs)
 plt.xlabel('Temperature $T$')
 plt.ylabel('Magnetization $|m|$')
 plt.title('2D Ising model')
 ```
-    
-One can clearly see that the magnetization rises from its zero high-temperature value to its saturation value at low $T$. The temperature at which it happens is not so clear, as the upturn gets sharper as system size is increased. To have a clearer idea, let us look at fluctuations of the magnetization.
 
-For this, let us consider the connected susceptibility $\chi = \beta N ( \langle m^2\rangle- \langle m\rangle^2)$, where $N$ is the total number of spins and where we subtracted the square of the average absolute value of magnetization, hence the name connected.
+The magnetization rises from zero at high temperature to its saturation value at low $T$.
+The upturn sharpens with increasing system size, but the precise transition temperature is hard to read off directly.
 
-```
+To locate the transition more precisely, examine fluctuations.
+The connected susceptibility $\chi = \beta N (\langle m^2 \rangle - \langle |m| \rangle^2)$ measures magnetization fluctuations and diverges at the critical point:
+
+```Python
 plt.figure()
 pyalps.plot.plot(connected_susc)
 plt.xlabel('Temperature $T$')
@@ -150,101 +151,111 @@ plt.ylabel('Connected Susceptibility $\chi_c$')
 plt.title('2D Ising model')
 ```
 
-One observes a marked peak around $T=2.2-2.4$, where fluctuations are strongest. We note that the peaks tend to diverge with system size; as we will see later, this divergence can be characterized by a critical exponent.
+A marked peak appears around $T = 2.2$–$2.4$, and the peak grows with system size.
+The specific heat $c_v = \beta^2 N (\langle e^2 \rangle - \langle e \rangle^2)$, where $e$ is the internal energy per site, shows a similar but less pronounced peak in the same range:
 
-This first rough estimation of the critical temperature is confirmed by looking at the behaviour of the specific heat, which characterizes fluctuations of energy : $c_v = \beta^2 N ( \langle e^2 \rangle - \langle e \rangle^2 )$, where $e$ is the internal energy per site.
-
-```
+```Python
 plt.figure()
 pyalps.plot.plot(spec_heat)
 plt.xlabel('Temperature $T$')
 plt.ylabel('Specific Heat $c_v$')
 plt.title('2D Ising model')
 ```
-    
-We observe here a peak, albeit less marked, around the same values of temperature. We will account for the less pronounced divergence of the specific heat peak later too.
 
-### Binder Cumulant
+### Binder cumulant
 
-Sometimes locating the maximum of a curve (such as the peaks in susceptibility or specific heat) is not always easy given the temperature grid used in the simulations. Moreover, and this can be seen in the previous plots, the peak temperature can drift with system size. This is also accounted for in the finite-size scaling theory outlined below.
+The Binder cumulant provides a sharper tool for locating the critical temperature.
+Define the ratio
 
-An alternative efficient way of locating phase transitions is through the use of cumulants. Let us consider the ratio $U_4=\langle m^4\rangle /\angle m^2\rangle^2$, first introduced by Binder and often called the Binder cumulant. At low temperature, this ratio tends to unity, whereas Gaussian fluctuations of the order parameter give a value 3 for $U_4$ in the high temperature phase. The non-trivial feature of the Binder cumulant resides in its value at the critical point, which can be shown to be universal and independent of the system size. Therefore, a plot of the Binder cumulant versus temperature allows a determination of $T_c$ at the crossing points of the curves with different system sizes:
+$$U_4 = \frac{\langle m^4 \rangle}{\langle m^2 \rangle^2},$$
 
-```
+which equals 1 in the fully ordered low-temperature phase and 3 for a Gaussian (high-temperature) order-parameter distribution.
+At the critical point its value is universal: it is the same for all system sizes, so curves for different $L$ all cross at $T_c$.
+
+```Python
 plt.figure()
 pyalps.plot.plot(binder_u4)
 plt.xlabel('Temperature $T$')
-plt.ylabel('Binder Cumulant U4 $g$')
+plt.ylabel('Binder Cumulant $U_4$')
 plt.title('2D Ising model')
 ```
 
-From this last plot, we thus conclude that the phase transition is located in the finer range  $T_c \in \[2.2,2.3\]$. One can also consider another cumulant $U_2 = \langle m^2\rangle / \langle |m|\rangle^2$, which is left as an exercise.
+From the crossing of the curves we can read off $T_c \in [2.2, 2.3]$.
+Another cumulant $U_2 = \langle m^2 \rangle / \langle |m| \rangle^2$ has the same crossing property and is left as an exercise.
 
-## Locate precisely the phase transition, first estimates of critical exponents, collapse plots
+## Precise determination of $T_c$ and critical exponents
 
-We can now try to more precisely determine the nature of the phase transition using a finer grid of temperature points in the critical range $T$ and using larger system sizes. For this, we will use the results of `parm7b`. As before we evaluate and load the specific observables from the result files.
+Using the finer temperature grid and larger system sizes from `parm7b`, we can extract $T_c$ and the critical exponents more accurately.
 
-```
+Load the results:
+
+```Python
 pyalps.evaluateSpinMC(pyalps.getResultFiles(prefix='parm7b'))
+data = pyalps.loadMeasurements(
+    pyalps.getResultFiles(prefix='parm7b'),
+    ['|Magnetization|', 'Connected Susceptibility', 'Specific Heat', 'Binder Cumulant', 'Binder Cumulant U2']
+)
+magnetization_abs = pyalps.collectXY(data, x='T', y='|Magnetization|',          foreach=['L'])
+connected_susc    = pyalps.collectXY(data, x='T', y='Connected Susceptibility',  foreach=['L'])
+spec_heat         = pyalps.collectXY(data, x='T', y='Specific Heat',             foreach=['L'])
+binder_u4         = pyalps.collectXY(data, x='T', y='Binder Cumulant',           foreach=['L'])
+binder_u2         = pyalps.collectXY(data, x='T', y='Binder Cumulant U2',        foreach=['L'])
 ```
 
-#### Load the observables and collect them as function of temperature T
+### Binder cumulant crossing
 
-```
-data = pyalps.loadMeasurements(pyalps.getResultFiles(prefix='parm7b'),['|Magnetization|', 'Connected Susceptibility', 'Specific Heat', 'Binder Cumulant', 'Binder Cumulant U2'])
-magnetization_abs = pyalps.collectXY(data,x='T',y='|Magnetization|',foreach=['L'])
-connected_susc = pyalps.collectXY(data,x='T',y='Connected Susceptibility',foreach=['L'])
-spec_heat = pyalps.collectXY(data,x='T',y='Specific Heat',foreach=['L'])
-binder_u4 = pyalps.collectXY(data,x='T',y='Binder Cumulant',foreach=['L'])
-binder_u2 = pyalps.collectXY(data,x='T',y='Binder Cumulant U2',foreach=['L'])
-```
-
-### Collapsing data
-
-We start with performing the Binder cumulant crossing:
-
-```
+```Python
 plt.figure()
 pyalps.plot.plot(binder_u4)
 plt.xlabel('Temperature $T$')
-plt.ylabel('Binder Cumulant U4 $g$')
+plt.ylabel('Binder Cumulant $U_4$')
 plt.title('2D Ising model')
 plt.show()
 ```
 
-What is the estimate of $T_c$ you obtain from this plot? There is more information in this plot. Indeed, the theory of finite size scaling indicates the following scaling form for the Binder cumulant $U_4 = f (L^{1/\nu} (T-T_c)/T_c)$, where $f$ is a universal function. For the different system sizes used in `parm7b`, plot the Binder cumulant as a function of $(T-T_c)/T_c$ where $T_c$ is the estimation you determined previously: all the curves should cross close to 0. Now try to find a good constant a such that when multiplied by $L^a$, all curves corresponding to system size $L$, collapse into a single master curve, i.e. the curve for $L=32$ should be multiplied by $32^a$, $L=48$ by $48^a$ etc.
+The crossing of the $L = 32$, $48$, and $64$ curves gives a refined estimate of $T_c$.
 
-Hint : Try a close to unity ...
+### Data collapse and the correlation-length exponent $\nu$
 
-#### Perform a data collapse of the Binder cumulant: 
+Finite-size scaling predicts that the Binder cumulant obeys the scaling form
 
-```
-Tc=... #your estimate
-a=...  #your estimate
+$$U_4 = f\!\left(L^{1/\nu}\,\frac{T - T_c}{T_c}\right),$$
+
+where $f$ is a universal function.
+Shifting the horizontal axis to $(T - T_c)/T_c$ should make the curves cross near zero.
+Multiplying by $L^a$ should then collapse all curves onto a single master curve when $a = 1/\nu$.
+Try values of $a$ close to 1:
+
+```Python
+Tc = ...   # your estimate from the Binder crossing
+a  = ...   # try values near 1.0
 
 for d in binder_u4:
     d.x -= Tc
-    d.x = d.x/Tc
-    l = d.props['L']
-    d.x = d.x * pow(float(l),a)
+    d.x  = d.x / Tc
+    l    = d.props['L']
+    d.x  = d.x * pow(float(l), a)
 
 plt.figure()
 pyalps.plot.plot(binder_u4)
-plt.xlabel('$L^a(T-T_c)/T_c$')
-plt.ylabel('Binder Cumulant U4 $g$')
+plt.xlabel('$L^{1/\\nu}(T-T_c)/T_c$')
+plt.ylabel('Binder Cumulant $U_4$')
 plt.title('2D Ising model')
 plt.show()
 ```
 
-What you are currently doing is a data collapse in the scaling regime, a famous technique to obtain critical exponents. In this case, you can read off the correlation length critical exponent: $\nu = 1/a$. The Binder cumulant collapse is very useful as it allows to determine $\nu$ independently of other critical exponents. A data collapse for other quantities often needs to also scale the quantity on the y-axis by some other exponent $L^b$.
+When the collapse is good, the correlation-length exponent is $\nu = 1/a$.
+This determination of $\nu$ is independent of all other critical exponents.
 
-### Critical exponents
+### Peak scaling of susceptibility and specific heat
 
-Now consider the specific heat and connected susceptibility:
+Finite-size scaling also predicts how the peak values of the susceptibility and specific heat grow with system size at $T_c$:
 
-#### Make a plot of the specific heat and connected susceptibility:
+$$\chi(T_c) \sim L^{\gamma/\nu}, \qquad C_v(T_c) \sim L^{\alpha/\nu}.$$
 
-```
+Note that the peak positions drift slightly with $L$ as $T_c(L) = T_c + A\,L^{-1/\nu}$, so you can evaluate the peaks either at the true $T_c$ from the Binder crossing or at the numerically determined peak temperature for each $L$.
+
+```Python
 plt.figure()
 pyalps.plot.plot(connected_susc)
 plt.xlabel('Temperature $T$')
@@ -258,124 +269,146 @@ plt.ylabel('Specific Heat $c_v$')
 plt.title('2D Ising model')
 plt.show()
 ```
-    
-Both connected susceptibility and specific heat peak at values of $T$ which are slightly different from the $T_c$ obtained with the Binder cumulant crossing. Such small differences are expected on small finite-systems: the effective critical temperature $T_c(L)$ that one can define at the position of the peaks is expected to drift with system size: $T_c(L) = T_c + A L^{-1/\nu}$. The constant $A$ can be different with different ways of defining $T_c(L)$. What about critical exponents? They can be read off from the value of the connected susceptibility or specific heat, either at $T_c(L)$ or at the $T_c$ obtained from the Binder cumulant. One expects the following scaling: $\chi (T_c) \sim L^{\gamma/\nu} and C_v (T_c) \sim L^{\alpha / \nu}$ For instance, locate the maximum of the connected susceptibility for the different curves, plot it as a function of $L$ and try a power-law fit. Note that by using relations between critical exponents $\gamma / \nu = 2 - \eta$. What value of $\eta$ do you obtain?
 
-#### Make a fit of the connected susceptibility as a function of $L$:
+#### Susceptibility peak fit
 
-```
-cs_mean=[]
-for q in connected_susc: 
+Extract the peak values and fit a power law in $L$:
+
+```Python
+cs_mean = []
+for q in connected_susc:
     cs_mean.append(np.array([d.mean for d in q.y]))
 
-peak_cs = pyalps.DataSet()
+peak_cs       = pyalps.DataSet()
 peak_cs.props = pyalps.dict_intersect([q.props for q in connected_susc])
-peak_cs.y = np.array([np.max(q) for q in cs_mean])
-peak_cs.x = np.array([q.props['L'] for q in connected_susc])
+peak_cs.y     = np.array([np.max(q) for q in cs_mean])
+peak_cs.x     = np.array([q.props['L'] for q in connected_susc])
 
-sel = np.argsort(peak_cs.x)
+sel       = np.argsort(peak_cs.x)
 peak_cs.y = peak_cs.y[sel]
 peak_cs.x = peak_cs.x[sel]
 
 pars = [fw.Parameter(1), fw.Parameter(1)]
-f = lambda self, x, pars: pars[0]()*np.power(x,pars[1]())
+f    = lambda self, x, pars: pars[0]() * np.power(x, pars[1]())
 fw.fit(None, f, pars, peak_cs.y, peak_cs.x)
-prefactor = pars[0].get()
 gamma_nu = pars[1].get()
 
 plt.figure()
 plt.plot(peak_cs.x, f(None, peak_cs.x, pars))
 pyalps.plot.plot(peak_cs)
 plt.xlabel('System Size $L$')
-plt.ylabel('Connected Susceptibility $\chi_c(T_c)$')
-plt.title('2D Ising model, $\gamma$ is %.4s' % gamma_nu)
+plt.ylabel('Connected Susceptibility $\\chi_c(T_c)$')
+plt.title('2D Ising model, $\\gamma/\\nu$ = %.4s' % gamma_nu)
 plt.show()
 ```
 
-Repeat the same procedure for the specific heat. What value of $\alpha$ do you obtain? Note that $\alpha$ can in general be positive or negative, meaning that the specific heat need not diverge at a continuous transition in contrast with the connected susceptibility.
+The fitted exponent gives $\gamma/\nu$.
+Using the hyperscaling relation $\gamma/\nu = 2 - \eta$, you can read off the anomalous dimension $\eta$.
 
-#### Make a fit of the specific heat as a function of $L$:
+#### Specific heat peak fit
 
-```
-sh_mean=[]
+Repeat the same analysis for the specific heat:
+
+```Python
+sh_mean = []
 for q in spec_heat:
     sh_mean.append(np.array([d.mean for d in q.y]))
-  
-peak_sh = pyalps.DataSet()
-peak_sh.props = pyalps.dict_intersect([q.props for q in spec_heat])
-peak_sh.y = np.array([np.max(q) for q in sh_mean])
-peak_sh.x = np.array([q.props['L'] for q in spec_heat])
 
-sel = np.argsort(peak_sh.x)
+peak_sh       = pyalps.DataSet()
+peak_sh.props = pyalps.dict_intersect([q.props for q in spec_heat])
+peak_sh.y     = np.array([np.max(q) for q in sh_mean])
+peak_sh.x     = np.array([q.props['L'] for q in spec_heat])
+
+sel       = np.argsort(peak_sh.x)
 peak_sh.y = peak_sh.y[sel]
-peak_sh.x = peak_sh.x[sel] 
+peak_sh.x = peak_sh.x[sel]
 
 pars = [fw.Parameter(1), fw.Parameter(1)]
-f = lambda self, x, pars: pars[0]()*np.power(x,pars[1]())
+f    = lambda self, x, pars: pars[0]() * np.power(x, pars[1]())
 fw.fit(None, f, pars, peak_sh.y, peak_sh.x)
-prefactor = pars[0].get()
 alpha_nu = pars[1].get()
+
 plt.figure()
 plt.plot(peak_sh.x, f(None, peak_sh.x, pars))
-pyalps.plot.plot(peak_cs)
+pyalps.plot.plot(peak_sh)
 plt.xlabel('System Size $L$')
 plt.ylabel('Specific Heat $c_v(T_c)$')
-plt.title(r'2D Ising model, $\alpha$ is %.4s' % alpha_nu)
+plt.title('2D Ising model, $\\alpha/\\nu$ = %.4s' % alpha_nu)
 plt.show()
 ```
-    
-As an exercise, you can repeat the same analysis for the absolute magnetization, which scales as $L^{-\beta/\nu}$.
 
-Also, try to perform a data collapse for the connected susceptibility and magnetization.
+Note that $\alpha$ can be positive or negative: the specific heat need not diverge as a power law at a continuous transition.
 
-Hint: The corresponding scaling forms are  $\chi = L^{2-\eta} g ( L^{1/\nu} (T-T_c)/T_c))$ and $|m| = L^{-\beta/\nu} h ( L^{1/\nu} (T-T_c)/T_c))$.
+### Data collapse for susceptibility and magnetization
 
-#### Make a data collapse of the connected susceptibility as a function of $(T-Tc)/T_c$:
+The full scaling forms are
 
-```
+$$\chi = L^{2-\eta}\, g\!\left(L^{1/\nu}\,\frac{T-T_c}{T_c}\right), \qquad |m| = L^{-\beta/\nu}\, h\!\left(L^{1/\nu}\,\frac{T-T_c}{T_c}\right),$$
+
+where $g$ and $h$ are universal functions.
+Using your estimates of $\nu$ and $T_c$ from the Binder collapse, tune $2-\eta$ to collapse the susceptibility curves:
+
+```Python
 for d in connected_susc:
     d.x -= Tc
-    d.x = d.x/Tc
-    l = d.props['L']
-    d.x = d.x * pow(float(l),a)
+    d.x  = d.x / Tc
+    l    = d.props['L']
+    d.x  = d.x * pow(float(l), a)
 
-two_minus_eta=... #your estimate
+two_minus_eta = ...   # your estimate
 for d in connected_susc:
-    l = d.props['L']
-    d.y = d.y/pow(float(l),two_eta)
+    l   = d.props['L']
+    d.y = d.y / pow(float(l), two_minus_eta)
 
 plt.figure()
 pyalps.plot.plot(connected_susc)
-plt.xlabel(' $L^a(T-T_c)/T_c$')
-plt.ylabel(r'$L^{\gamma/\nu}\chi_c$')
+plt.xlabel('$L^{1/\\nu}(T-T_c)/T_c$')
+plt.ylabel('$L^{-(2-\\eta)}\\chi_c$')
 plt.title('2D Ising model')
 plt.show()
 ```
-    
-#### Make a data collapse of the |magnetization| as a function of $(T-Tc)/T_c$
 
-```
+And tune $\beta/\nu$ to collapse the magnetization curves:
+
+```Python
 for d in magnetization_abs:
     d.x -= Tc
-    d.x = d.x/Tc
-    l = d.props['L']
-    d.x = d.x * pow(float(l),a)
-    
-beta_over_nu=... #your estimate    
+    d.x  = d.x / Tc
+    l    = d.props['L']
+    d.x  = d.x * pow(float(l), a)
+
+beta_over_nu = ...   # your estimate
 for d in magnetization_abs:
-    l = d.props['L']
-    d.y = d.y / pow(float(l),-beta_over_nu)
- 
+    l   = d.props['L']
+    d.y = d.y / pow(float(l), -beta_over_nu)
+
 plt.figure()
 pyalps.plot.plot(magnetization_abs)
-plt.xlabel(' $L^a(T-T_c)/T_c$')
-plt.ylabel(r'$L^{-\beta/\nu} |m|$')
+plt.xlabel('$L^{1/\\nu}(T-T_c)/T_c$')
+plt.ylabel('$L^{\\beta/\\nu}|m|$')
 plt.title('2D Ising model')
-plt.show()   
-```                                                                                                                                                                               
+plt.show()
+```
 
-## Precise estimates of critical exponents
+## Exact values and comparison
 
-The exact critical exponents of the 2d Ising are : $\nu=1$, $\eta=1/4$, $\beta=1/8$ and $\alpha=0$. On this last exponent: the specific heat does diverge, but logarithmically, not as power-law and hence the specific heat exponent is 0 dimensional. How do you compare your estimates with the exact values ?
+The exact critical exponents of the 2D Ising model are
 
-The quality of the estimates one obtains for the critical exponents and temperature increases considerably when using larger system sizes, which are not accessible within the time scale of this tutorial. Moreover, they also rely on the quality of the estimate of the critical temperature. For more precision on critical exponents, one can enforce the exact value of the critical temperature $T_c = 2 / \ln(1+\sqrt{2}) = 2.269\ldots$ and simulate larger system sizes, which we leave to you as an exercise. Since there is only one value of temperature as a parameter, the previous way of determining $\nu$ through a data collapse is not that helpful. The above scaling form for the Binder cumulant allows for another, more direct determination of $\nu$. Deriving the Binder cumulant with respect to $T$, one easily sees that the derivative $dU_4/dT$ scales as $L^{1/\nu}$ at $T_c$. You can either obtain this derivative from a numerical differentiation of your data, or better, it can also be obtained as a thermodynamical average during the Monte Carlo simulations. Note that this requires good statistics. Once you have obtained the data, the exponent $\nu$ can be determined by a power-law fit of this derivative $dU_4/dT$ at T_c as a function of system size $L$ .
+$$\nu = 1, \quad \eta = \tfrac{1}{4}, \quad \beta = \tfrac{1}{8}, \quad \alpha = 0.$$
+
+For $\alpha = 0$: the specific heat diverges logarithmically rather than as a power law, so a power-law fit returns an exponent close to zero but not exactly zero.
+How do your numerical estimates compare with these exact values?
+
+For more precise estimates, fix the critical temperature to the exact value $T_c = 2/\ln(1+\sqrt{2}) \approx 2.2692$ and simulate larger system sizes.
+With $T_c$ fixed, a useful way to extract $\nu$ is via the derivative of the Binder cumulant.
+At $T_c$, finite-size scaling implies $dU_4/dT \sim L^{1/\nu}$, so a power-law fit of this derivative as a function of $L$ gives $\nu$ directly.
+The derivative can be obtained by numerical differentiation of the Monte Carlo data, or measured as a thermodynamic average during the simulation (which requires good statistics).
+
+## Questions
+
+- At what temperature do the Binder cumulant curves cross? How does your estimate compare with the exact value $T_c \approx 2.2692$?
+- What value of $\nu$ do you extract from the Binder cumulant data collapse? Compare with the exact value $\nu = 1$.
+- The susceptibility peak grows strongly with system size while the specific heat peak grows much more slowly. What does this imply about $\alpha$?
+- Using $\gamma/\nu = 2 - \eta$, what value of $\eta$ do you obtain? Compare with the exact value $\eta = 1/4$.
+- Try increasing `SWEEPS` for the largest system sizes. How does this improve the quality of the data collapse?
+- (Advanced) Compute $dU_4/dT$ numerically and verify the $L^{1/\nu}$ scaling.


### PR DESCRIPTION
## Summary

- Fix bugs: `\angle` → `\langle` in Binder cumulant definition, undefined `two_eta` → `two_minus_eta`, wrong dataset in specific heat fit plot (`peak_cs` → `peak_sh`), plot titles showing γ/α instead of γ/ν and α/ν
- Fix broken inline math where "and" appeared between two LaTeX expressions
- Rewrite prose and structure to match MC-02 style: intro paragraph without heading, `####` subsections for CLI vs Python setup, explanatory text before every code block, display math for all key equations, Questions section at the end

## Test plan

- [ ] LaTeX renders correctly (Binder cumulant definition, FSS scaling forms, exact exponents)
- [ ] Python code blocks are syntactically valid
- [ ] Download links for `parm7a`, `parm7b`, `tutorial7a.py`, `tutorial7b.py` resolve
- [ ] Prose is physically accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)