### PR TITLE
Rewrite MC-03 magnetization tutorial

### DIFF
--- a/content/en/tutorials/mcs/mc03.md
+++ b/content/en/tutorials/mcs/mc03.md
@@ -100,7 +100,7 @@ plt.figure()
 pyalps.plot.plot(magnetization)
 plt.xlabel('Field $h/J$')
 plt.ylabel('Magnetization $m$')
-plt.ylim(0.0, 0.5)
+plt.ylim(0.0, 0.55)
 plt.title('Quantum Heisenberg chain')
 plt.show()
 ```
@@ -154,7 +154,7 @@ dirloop_sse --Tmin 10 --write-xml parm3b.in.xml
 
 #### Setting up and running in Python
 
-The script <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-03-magnetization/tutorial3b.py" download>`tutorial3b.py`</a> adapts `tutorial3a.py`: rename the prefix to `parm3b`, change `LATTICE` to `"ladder"`, replace `J` with `J0` and `J1` (both `1`), and extend the field scan to 3.5.
+The script <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-03-magnetization/tutorial3b.py" download>`tutorial3b.py`</a> adapts `tutorial3a.py`: rename the prefix to `parm3b`, change `LATTICE` to `"ladder"`, replace `J` with `J0=J1=1`, and extend the field scan to 3.5.
 
 #### Evaluating and plotting
 
@@ -166,7 +166,7 @@ plt.figure()
 pyalps.plot.plot(magnetization)
 plt.xlabel('Field $h/J$')
 plt.ylabel('Magnetization $m$')
-plt.ylim(0.0, 0.5)
+plt.ylim(0.0, 0.55)
 plt.title('Quantum Heisenberg ladder')
 plt.show()
 ```
@@ -195,7 +195,7 @@ plt.figure()
 pyalps.plot.plot(magnetization)
 plt.xlabel('Field $h/J$')
 plt.ylabel('Magnetization $m$')
-plt.ylim(0.0, 0.5)
+plt.ylim(0.0, 0.55)
 plt.legend()
 plt.title('Quantum Heisenberg models')
 plt.show()

--- a/content/en/tutorials/mcs/mc03.md
+++ b/content/en/tutorials/mcs/mc03.md
@@ -154,7 +154,7 @@ dirloop_sse --Tmin 10 --write-xml parm3b.in.xml
 
 #### Setting up and running in Python
 
-The script <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-03-magnetization/tutorial3b.py" download>`tutorial3b.py`</a> adapts `tutorial3a.py`: rename the prefix to `parm3b`, change `LATTICE` to `"ladder"`, and replace `J` with `J0` and `J1` (both `1`), and extend the field scan to 3.5.
+The script <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-03-magnetization/tutorial3b.py" download>`tutorial3b.py`</a> adapts `tutorial3a.py`: rename the prefix to `parm3b`, change `LATTICE` to `"ladder"`, replace `J` with `J0` and `J1` (both `1`), and extend the field scan to 3.5.
 
 #### Evaluating and plotting
 

--- a/content/en/tutorials/mcs/mc03.md
+++ b/content/en/tutorials/mcs/mc03.md
@@ -210,7 +210,7 @@ The combined plot makes the contrast between the gapless chain and the gapped la
 - At what field does the chain magnetization begin to rise? What does this tell you about the spin gap of the chain?
 - Estimate the lower critical field $h_{c1}$ of the ladder from your data. How does it compare with the known spin gap $\Delta \approx 0.5J$?
 - Both models saturate at $m = 1/2$. At what field does saturation occur in each case, and why are the saturation fields different?
-- Repeat the simulation at a higher temperature, e.g. $T = 0.5$. How does thermal fluctuations affect the sharpness of the features in the magnetization curve?
+- Repeat the simulation at a higher temperature, e.g. $T = 0.5$. How do thermal fluctuations affect the sharpness of the features in the magnetization curve?
 - (Bonus) Try a 3-leg or 4-leg ladder by adding a `W` parameter for the width, or change `local_S` to study spin-1 or spin-3/2 chains. Is there a systematic pattern in the critical fields?
 
 <!--

--- a/content/en/tutorials/mcs/mc03.md
+++ b/content/en/tutorials/mcs/mc03.md
@@ -6,19 +6,25 @@ toc: true
 weight: 5
 ---
 
-## Magnetization curves of quantum spin models
+This tutorial studies magnetization curves $m(h)$ of the $S = 1/2$ Heisenberg model on two geometries: a one-dimensional chain and a two-leg ladder.
+Because the `looper` QMC code does not perform well in a magnetic field, we use the directed-loop SSE application `dirloop_sse` instead.
 
-In this tutorial we will look at magnetization curves of quantum spin models using the directed loop SSE application instead of loop, since loop does not perform well in a magnetic field.
+The two geometries produce qualitatively different magnetization curves.
+The Heisenberg chain is gapless: its magnetization rises smoothly from $m = 0$ as soon as a field is applied.
+The two-leg ladder has a spin gap $\Delta \approx 0.5J$: the magnetization stays exactly zero for $h < \Delta$ and only begins to rise at a finite critical field, giving a distinctive plateau at $m = 0$.
 
-### One-dimensional Heisenberg chain in a magnetic field
+## One-dimensional Heisenberg chain
 
-#### Preparing and running the simulation from the command line
+We simulate the $S = 1/2$ antiferromagnetic Heisenberg chain with 20 sites at temperature $T = 0.08$ across a range of magnetic fields $h = 0, 0.1, \ldots, 2.5$.
+The temperature is low enough that the results are close to the ground-state magnetization curve.
 
-The parameter file <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-03-magnetization/parm3a" download>`parm3a`</a> sets up Monte Carlo simulations of the quantum mechanical S=1/2 Heisenberg model on a one-dimensional chain with 20 sites at fixed temperature T=0.08 for a couple of magnetic fields (h=0, 0.1, ..., 2.5).
+#### Setting up and running on the command line
 
-```Python
-LATTICE="chain lattice" 
-MODEL   = "spin"
+The parameter file <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-03-magnetization/parm3a" download>`parm3a`</a>:
+
+```
+LATTICE="chain lattice"
+MODEL="spin"
 local_S=1/2
 L=20
 J=1
@@ -45,17 +51,17 @@ SWEEPS=10000
 {h=2.4;}
 {h=2.5;}
 ```
-    
-Using the following standard sequence of commands, you can run the simulation using the quantum SSE code. As usual, XML output files may be viewed in a web browser.
 
-```Python
+Convert and run using the SSE code:
+
+```
 parameter2xml parm3a
 dirloop_sse --Tmin 10 --write-xml parm3a.in.xml
 ```
-    
-#### Preparing and running the simulation using Python
 
-Setting up and running the simulation in Python is as before, with the script <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-03-magnetization/tutorial3a.py" download>`tutorial3a.py`</a>:
+#### Setting up and running in Python
+
+The script <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-03-magnetization/tutorial3a.py" download>`tutorial3a.py`</a>:
 
 ```Python
 import pyalps
@@ -65,12 +71,12 @@ import pyalps.plot
 parms = []
 for h in [0., 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.2, 2.4, 2.5]:
     parms.append(
-        { 
-            'LATTICE'        : "chain lattice", 
+        {
+            'LATTICE'        : "chain lattice",
             'MODEL'          : "spin",
             'local_S'        : 0.5,
             'T'              : 0.08,
-            'J'              : 1 ,
+            'J'              : 1,
             'THERMALIZATION' : 1000,
             'SWEEPS'         : 20000,
             'L'              : 20,
@@ -78,60 +84,134 @@ for h in [0., 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.2, 1.4, 1.6, 1
         }
     )
 
-input_file = pyalps.writeInputFiles('parm3a',parms)
-res = pyalps.runApplication('dirloop_sse',input_file,Tmin=5)
-```
-    
-We now have the same output files as in the command line version.
-
-#### Evaluating the simulation and preparing plots using Python
-
-To load the results and prepare plots we load the results from the output files and collect the magntization density as a function of magnetic field from all output files starting with `parm3a`.
-
-```Python
-data = pyalps.loadMeasurements(pyalps.getResultFiles(prefix='parm3a'),'Magnetization Density')
-magnetization = pyalps.collectXY(data,x='h',y='Magnetization Density')
+input_file = pyalps.writeInputFiles('parm3a', parms)
+pyalps.runApplication('dirloop_sse', input_file, Tmin=5)
 ```
 
-To make plots we call the `pyalps.pyplot.plot` and then set some nice labels, a title, and a range of y-values:
+#### Evaluating and plotting
+
+Load the magnetization density and plot it as a function of field:
 
 ```Python
+data = pyalps.loadMeasurements(pyalps.getResultFiles(prefix='parm3a'), 'Magnetization Density')
+magnetization = pyalps.collectXY(data, x='h', y='Magnetization Density')
+
 plt.figure()
 pyalps.plot.plot(magnetization)
-plt.xlabel('Field $h$')
+plt.xlabel('Field $h/J$')
 plt.ylabel('Magnetization $m$')
-plt.ylim(0.0,0.5)
+plt.ylim(0.0, 0.5)
 plt.title('Quantum Heisenberg chain')
 plt.show()
 ```
-    
-### One-dimensional Heisenberg ladder in a magnetic field
 
-The parameter file <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-03-magnetization/parm3b" download>`parm3b`</a> sets up Monte Carlo simulations of the quantum mechanical S=1/2 Heisenberg model on a one-dimensional ladder with 40 sites at fixed temperature T=0.08 for a couple of magnetic fields (h=0, 0.1, ..., 3.5).
+The magnetization rises continuously from zero, reaching saturation $m = 1/2$ at the saturation field $h_\text{sat} = 2J$.
 
-```Python
-LATTICE="ladder" 
-MODEL   = "spin"
+## One-dimensional Heisenberg ladder
+
+The two-leg ladder adds rung couplings $J_1$ connecting the two chains.
+We use 20 rungs (40 sites total) and extend the field range to $h = 3.5$ to reach saturation.
+
+#### Setting up and running on the command line
+
+The parameter file <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-03-magnetization/parm3b" download>`parm3b`</a> uses the same structure as `parm3a` with these changes:
+
+```
+LATTICE="ladder"
+MODEL="spin"
 local_S=1/2
 L=20
 J0=1
 J1=1
 T=0.08
+THERMALIZATION=2000
+SWEEPS=10000
+{h=0;}
+{h=0.2;}
+{h=0.4;}
+{h=0.6;}
+{h=0.8;}
+{h=1.0;}
+{h=1.2;}
+{h=1.4;}
+{h=1.6;}
+{h=1.8;}
+{h=2.0;}
+{h=2.2;}
+{h=2.4;}
+{h=2.6;}
+{h=2.8;}
+{h=3.0;}
+{h=3.2;}
+{h=3.4;}
+{h=3.5;}
 ```
-    
-The rest of the input file is as above and simulations are run in the same way. The corresponding script is downloadable <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-03-magnetization/tutorial3b.py" download>here.</a>
 
-### Combining all simulations
+```
+parameter2xml parm3b
+dirloop_sse --Tmin 10 --write-xml parm3b.in.xml
+```
 
-The procedure to combine all results into one plot after running both simulations is extremely similar to the previous tutorial. The script is downloadable <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-03-magnetization/tutorial3full.py" download>here.</a> Here is the combined plot:
+#### Setting up and running in Python
+
+The script <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-03-magnetization/tutorial3b.py" download>`tutorial3b.py`</a> adapts `tutorial3a.py`: rename the prefix to `parm3b`, change `LATTICE` to `"ladder"`, and replace `J` with `J0` and `J1` (both `1`), and extend the field scan to 3.5.
+
+#### Evaluating and plotting
+
+```Python
+data = pyalps.loadMeasurements(pyalps.getResultFiles(prefix='parm3b'), 'Magnetization Density')
+magnetization = pyalps.collectXY(data, x='h', y='Magnetization Density')
+
+plt.figure()
+pyalps.plot.plot(magnetization)
+plt.xlabel('Field $h/J$')
+plt.ylabel('Magnetization $m$')
+plt.ylim(0.0, 0.5)
+plt.title('Quantum Heisenberg ladder')
+plt.show()
+```
+
+In contrast to the chain, the ladder magnetization is zero up to a finite lower critical field $h_{c1} \approx \Delta \approx 0.5J$, reflecting the spin gap, before rising to saturation at $h_{c2}$.
+
+## Combining both simulations
+
+After running both simulations in the same folder, the script <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-03-magnetization/tutorial3full.py" download>`tutorial3full.py`</a> overlays the two magnetization curves on a single plot:
+
+```Python
+import pyalps
+import matplotlib.pyplot as plt
+import pyalps.plot
+
+data = pyalps.loadMeasurements(pyalps.getResultFiles(), 'Magnetization Density')
+magnetization = pyalps.collectXY(data, x='h', y='Magnetization Density', foreach=['LATTICE'])
+
+for m in magnetization:
+    if m.props['LATTICE'] == 'chain lattice':
+        m.props['label'] = 'chain'
+    elif m.props['LATTICE'] == 'ladder':
+        m.props['label'] = 'ladder'
+
+plt.figure()
+pyalps.plot.plot(magnetization)
+plt.xlabel('Field $h/J$')
+plt.ylabel('Magnetization $m$')
+plt.ylim(0.0, 0.5)
+plt.legend()
+plt.title('Quantum Heisenberg models')
+plt.show()
+```
+
+The combined plot makes the contrast between the gapless chain and the gapped ladder immediately visible.
 
 ![](/figs/mcs03mvsh.png)
 
 ## Questions
 
-- How does the magnetization depend on the magnetic field?
-- How does the magnetization depend on the lattice?
-- Bonus: You can also study a 3-leg, 4-leg ladder by changing the parameter W for the width or a spin-1, spin-3/2 chain by changing the parameter local_S. Is there a systematic behavior?
+- At what field does the chain magnetization begin to rise? What does this tell you about the spin gap of the chain?
+- Estimate the lower critical field $h_{c1}$ of the ladder from your data. How does it compare with the known spin gap $\Delta \approx 0.5J$?
+- Both models saturate at $m = 1/2$. At what field does saturation occur in each case, and why are the saturation fields different?
+- Repeat the simulation at a higher temperature, e.g. $T = 0.5$. How does thermal fluctuations affect the sharpness of the features in the magnetization curve?
+- (Bonus) Try a 3-leg or 4-leg ladder by adding a `W` parameter for the width, or change `local_S` to study spin-1 or spin-3/2 chains. Is there a systematic pattern in the critical fields?
 
 <!--
 ## Walkthrough Video


### PR DESCRIPTION
## Summary

- Fix code block languages: ALPS parameter files and shell commands were incorrectly tagged as `Python`
- Fix typo: "magntization" → "magnetization"
- Expand the ladder section with a complete parameter file and full evaluation code (previously just said "rest is as above" and pointed to a download link)
- Add the combining-simulations code inline rather than just linking to `tutorial3full.py`
- Add a physics intro explaining the gapless chain vs gapped ladder contrast (spin gap, plateau at $m=0$, critical fields)
- Improve the questions to ask about physical interpretation rather than just "how does $m$ depend on $h$?"

## Test plan

- [ ] Code blocks render with correct syntax highlighting
- [ ] Download links for `parm3a`, `parm3b`, `tutorial3a.py`, `tutorial3b.py`, `tutorial3full.py` resolve
- [ ] Figure `mcs03mvsh.png` renders correctly
- [ ] Combining-simulations code is syntactically valid Python
- [ ] YouTube embed still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)