### PR TITLE
Rewrite MC-05 bosons tutorial

### DIFF
--- a/content/en/tutorials/mcs/mc05.md
+++ b/content/en/tutorials/mcs/mc05.md
@@ -6,140 +6,214 @@ toc: true
 weight: 7
 ---
 
-## Quantum phase transitions in the Bose-Hubbard model
+The Bose-Hubbard model describes interacting bosons on a lattice:
 
-As an example of the worm QMC code, we will study a quantum phase transition in the Bose-Hubbard mode.
+$$H = -t \sum_{\langle i,j \rangle} (a_i^\dagger a_j + \text{h.c.}) + \frac{U}{2} \sum_i n_i(n_i-1) - \mu \sum_i n_i,$$
 
-### Superfluid density in the Bose Hubbard model
+where $t$ is the hopping amplitude, $U$ the on-site repulsion, and $\mu$ the chemical potential.
+At integer filling and large $U/t$ the system is a **Mott insulator**: bosons are localized by interactions and the superfluid density $\rho_s = 0$.
+As $t/U$ increases, quantum fluctuations eventually drive a transition to a **superfluid** phase with $\rho_s > 0$.
+This tutorial uses the ALPS worm QMC code to locate this quantum phase transition on a two-dimensional square lattice at filling $\langle n \rangle = 1$ (set by $\mu = U/2 = 0.5$).
 
-#### Preparing and running the simulation from the command line
+## Superfluid density across the transition
 
-The parameter file <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-05-bosons/parm5a" download>`parm5a`</a> with the following contents sets up Monte Carlo simulations of the quantum Bose Hubbard model on a square lattice with 4x4 sites for a couple of hopping parameters (t=0.01, 0.02, ..., 0.1) using the worm code.
+We first scan a wide range of hopping values on a $4 \times 4$ lattice to observe how the superfluid density $\rho_s$ (called "Stiffness" in ALPS) evolves across the transition.
+The Hilbert space is truncated at `Nmax=2` bosons per site, which is a good approximation near the Mott lobe at unit filling.
 
-```
-LATTICE="square lattice";
-L=4;
-MODEL="boson Hubbard";
-NONLOCAL=0;
-U    = 1.0;
-mu   = 0.5;
-Nmax = 2;
-T = 0.1;
-SWEEPS=500000;
-THERMALIZATION=10000;
-{ t=0.01; }
-{ t=0.02; }
-{ t=0.03; }
-{ t=0.04; }
-{ t=0.05; }
-{ t=0.06; }
-{ t=0.07; }
-{ t=0.08; }
-{ t=0.09; }
-{ t=0.1; }
-```
+#### Setting up and running on the command line
 
-The corresponding Python script is found at <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-05-bosons/tutorial5a.py" download>`tutorial5a.py`</a>.
-
-#### Evaluating the simulation and preparing plots using Python
-
-To load the results and prepare plots we load the results from the output files and collect the magntization density as a function of magnetic field from all output files starting with `parm5a`.
+The parameter file <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-05-bosons/parm5a" download>`parm5a`</a>:
 
 ```
-data = pyalps.loadMeasurements(pyalps.getResultFiles(prefix='parm5a'),'Stiffness')
-magnetization = pyalps.collectXY(data,x='h',y='Stiffness')
+LATTICE="square lattice"
+L=4
+MODEL="boson Hubbard"
+NONLOCAL=0
+U=1.0
+mu=0.5
+Nmax=2
+T=0.1
+SWEEPS=500000
+THERMALIZATION=10000
+{t=0.01;}
+{t=0.02;}
+{t=0.03;}
+{t=0.04;}
+{t=0.05;}
+{t=0.06;}
+{t=0.07;}
+{t=0.08;}
+{t=0.09;}
+{t=0.1;}
 ```
 
-To make plots we call the pyalps.plot.plot and then set some nice labels, a title, and a range of y-values:
+`NONLOCAL=0` disables non-local measurements to keep the output compact.
 
 ```
+parameter2xml parm5a
+worm --Tmin 10 --write-xml parm5a.in.xml
+```
+
+#### Setting up and running in Python
+
+The script <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-05-bosons/tutorial5a.py" download>`tutorial5a.py`</a>:
+
+```Python
+import pyalps
+import matplotlib.pyplot as plt
+import pyalps.plot
+
+parms = []
+for t in [0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1]:
+    parms.append(
+        {
+            'LATTICE'        : "square lattice",
+            'L'              : 4,
+            'MODEL'          : "boson Hubbard",
+            'NONLOCAL'       : 0,
+            'U'              : 1.0,
+            'mu'             : 0.5,
+            'Nmax'           : 2,
+            'T'              : 0.1,
+            'SWEEPS'         : 500000,
+            'THERMALIZATION' : 10000,
+            't'              : t
+        }
+    )
+
+input_file = pyalps.writeInputFiles('parm5a', parms)
+pyalps.runApplication('worm', input_file, Tmin=5)
+```
+
+#### Evaluating and plotting
+
+Load the superfluid stiffness and plot it as a function of hopping:
+
+```Python
+data = pyalps.loadMeasurements(pyalps.getResultFiles(prefix='parm5a'), 'Stiffness')
+rhos = pyalps.collectXY(data, x='t', y='Stiffness')
+
 plt.figure()
 pyalps.plot.plot(rhos)
 plt.xlabel('Hopping $t/U$')
-plt.ylabel('Superfluid density $\\rho _s$')
+plt.ylabel('Superfluid density $\\rho_s$')
+plt.title('Bose-Hubbard model on a $4\\times 4$ lattice')
 plt.show()
 ```
 
-#### Questions
+$\rho_s$ should be small (consistent with zero) for small $t/U$ and grow to a finite value for large $t/U$, with a crossover near the critical hopping $(t/U)_c \approx 0.060$.
 
-What is the signature of the phase transition?
+## Locating the critical point
 
-### The transition from the Mott insulator to the superfluid
+To pin down $(t/U)_c$ more precisely we exploit finite-size scaling.
+At the quantum critical point, $\rho_s \sim L^{-(d+z-2)}$ where $d=2$ is the dimension and $z=1$ is the dynamical exponent for this universality class (3D XY).
+For $d=2$, $z=1$ this gives $\rho_s \sim L^{-1}$, so the combination $\rho_s L$ is dimensionless at criticality and curves for different $L$ cross at $t_c$.
 
-We next want to pin down the location of the phase transition more accurately. For this we simulate a two-dimensional square lattice for various system sizes and look for a crossing of the quantity $\rho_s L$.
+We simulate three system sizes $L = 4, 6, 8$ on a fine grid of hopping values around the expected critical point.
 
-#### Preparing and running the simulation from the command line
+#### Setting up and running on the command line
 
-In the parameter file <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-05-bosons/parm5b" download>`parm5b`</a> we focus on the region around the critical point for three system sizes L=4, 6, and 8:
-
-```
-LATTICE="square lattice";
-MODEL="boson Hubbard";
-NONLOCAL=0;
-U    = 1.0;
-mu   = 0.5;
-Nmax = 2;
-T = 0.05;
-SWEEPS=600000;
-THERMALIZATION=150000;
-{ L=4; t=0.045; }
-{ L=4; t=0.05; }
-{ L=4; t=0.0525; }
-{ L=4; t=0.055; }
-{ L=4; t=0.0575; }
-{ L=4; t=0.06; }
-{ L=4; t=0.065; }
-{ L=6; t=0.045; }
-{ L=6; t=0.05; }
-{ L=6; t=0.0525; }
-{ L=6; t=0.055; }
-{ L=6; t=0.0575; }
-{ L=6; t=0.06; }
-{ L=6; t=0.065; }
-{ L=8; t=0.045; }
-{ L=8; t=0.05; }
-{ L=8; t=0.0525; }
-{ L=8; t=0.055; }
-{ L=8; t=0.0575; }
-{ L=8; t=0.06; }
-{ L=8; t=0.065; }
-```
-    
-The corresponding Python script is found at <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-05-bosons/tutorial5b.py" download>`tutorial5b.py`</a>.
-
-#### Evaluating the simulation using Python
-
-We first load the superfluid density (stiffness) into three different data sets, one for each system size L:
+The parameter file <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-05-bosons/parm5b" download>`parm5b`</a>:
 
 ```
-data = pyalps.loadMeasurements(pyalps.getResultFiles(prefix='parm5b'),'Stiffness')
-rhos = pyalps.collectXY(data,x='t',y='Stiffness',foreach=['L'])
+LATTICE="square lattice"
+MODEL="boson Hubbard"
+NONLOCAL=0
+U=1.0
+mu=0.5
+Nmax=2
+T=0.05
+SWEEPS=600000
+THERMALIZATION=150000
+{L=4; t=0.045;}
+{L=4; t=0.05;}
+{L=4; t=0.0525;}
+{L=4; t=0.055;}
+{L=4; t=0.0575;}
+{L=4; t=0.06;}
+{L=4; t=0.065;}
+{L=6; t=0.045;}
+{L=6; t=0.05;}
+{L=6; t=0.0525;}
+{L=6; t=0.055;}
+{L=6; t=0.0575;}
+{L=6; t=0.06;}
+{L=6; t=0.065;}
+{L=8; t=0.045;}
+{L=8; t=0.05;}
+{L=8; t=0.0525;}
+{L=8; t=0.055;}
+{L=8; t=0.0575;}
+{L=8; t=0.06;}
+{L=8; t=0.065;}
 ```
 
-Next we multiply each data set by the size L:
+The lower temperature ($T = 0.05$) and longer runs compared to `parm5a` are needed to resolve the crossing clearly.
 
 ```
+parameter2xml parm5b
+worm --Tmin 10 --write-xml parm5b.in.xml
+```
+
+#### Setting up and running in Python
+
+The script <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-05-bosons/tutorial5b.py" download>`tutorial5b.py`</a> adapts `tutorial5a.py`: rename the prefix to `parm5b`, lower `T` to 0.05, increase `THERMALIZATION` to 150000 and `SWEEPS` to 600000, and loop over both `L` and `t`:
+
+```Python
+import pyalps
+import matplotlib.pyplot as plt
+import pyalps.plot
+
+parms = []
+for L in [4, 6, 8]:
+    for t in [0.045, 0.05, 0.0525, 0.055, 0.0575, 0.06, 0.065]:
+        parms.append(
+            {
+                'LATTICE'        : "square lattice",
+                'L'              : L,
+                'MODEL'          : "boson Hubbard",
+                'NONLOCAL'       : 0,
+                'U'              : 1.0,
+                'mu'             : 0.5,
+                'Nmax'           : 2,
+                'T'              : 0.05,
+                'SWEEPS'         : 600000,
+                'THERMALIZATION' : 150000,
+                't'              : t
+            }
+        )
+
+input_file = pyalps.writeInputFiles('parm5b', parms)
+pyalps.runApplication('worm', input_file, Tmin=5)
+```
+
+#### Evaluating and plotting
+
+Load the stiffness for each system size, multiply by $L$, and plot:
+
+```Python
+data = pyalps.loadMeasurements(pyalps.getResultFiles(prefix='parm5b'), 'Stiffness')
+rhos = pyalps.collectXY(data, x='t', y='Stiffness', foreach=['L'])
+
 for s in rhos:
     s.y = s.y * float(s.props['L'])
-```
 
-And finally we make a plot in the usual way:
-
-```
 plt.figure()
-pyalps.pyplot.plot(rhos)
+pyalps.plot.plot(rhos)
 plt.xlabel('Hopping $t/U$')
-plt.ylabel('$\\rho _sL$')
+plt.ylabel('$\\rho_s L$')
 plt.legend()
-plt.title('Scaling plot for Bose-Hubbard model')
+plt.title('Finite-size scaling: Bose-Hubbard model')
 plt.show()
 ```
 
-Note the legend and labels that are nicely set up.
+The curves for $L = 4, 6, 8$ should cross near $(t/U)_c$.
+The exact result for the 2D Bose-Hubbard model at unit filling is $(t/U)_c = 0.05974\ldots$
 
-#### Questions
+## Questions
 
-- How can you determine the location of the quantum phase transition in the thermodynamic limit?
-- Tip: Multiply your results for the superfluid stiffness by the respective linear system size L.
-- Compare your result to the exact result (t/U)c = 0.05974...
-- Why does the Monte Carlo simulation overestimate the critical point of the transition?
+- At what hopping value does $\rho_s$ first become clearly nonzero in the coarse scan? Does this agree with the crossing in the $\rho_s L$ plot?
+- Where do the $\rho_s L$ curves cross? How does your estimate compare with the exact value $(t/U)_c = 0.05974$?
+- The finite-temperature simulations systematically overestimate $(t/U)_c$. Why? What would happen to the crossing point if you lowered $T$ further?
+- Try increasing `Nmax` to 3. How much do the results change? At what filling or interaction strength would `Nmax=2` become a poor approximation?
+- (Bonus) Repeat the finite-size scaling analysis with larger system sizes. How does the quality of the crossing improve?


### PR DESCRIPTION
## Summary

- Fix copy-paste bug from MC-04: evaluation code loaded `'Stiffness'` but stored it in variable `magnetization` and used `x='h'` (magnetic field) instead of `x='t'` (hopping parameter)
- Fix undefined variable: plot code referenced `rhos` immediately after defining `magnetization`
- Fix `pyalps.pyplot.plot` → `pyalps.plot.plot`
- Fix typo: "Bose-Hubbard mode" → "Bose-Hubbard model"
- Add `Python` language tags to all code blocks
- Show the full Python scripts for both simulations inline instead of just linking to them
- Add a physics intro with the Bose-Hubbard Hamiltonian and explanation of the Mott insulator to superfluid transition
- Add finite-size scaling explanation for the $\rho_s L$ crossing method and its connection to the 3D XY universality class
- Consolidate inline questions into a single `## Questions` section at the end with physically motivated prompts

## Test plan

- [ ] Python code is valid Python 3 and variable names are consistent throughout
- [ ] Download links for `parm5a`, `parm5b`, `tutorial5a.py`, `tutorial5b.py` resolve
- [ ] Parameter files and Python versions are consistent with each other
- [ ] Physics (Mott transition, $\rho_s L$ crossing, exact critical point) is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)