### PR TITLE
docs: improve source installation guide for beginners

### DIFF
--- a/content/en/documentation/install/source.md
+++ b/content/en/documentation/install/source.md
@@ -278,7 +278,32 @@ To install the code run:
   ```ShellSession
   $ cmake --install alps-build
   ```
-Your install directory will be created; if everything was successful you can find ALPS executables such as `spinmc` or `fulldiag` under the bin directory of your installation path.
+
+### Set up your environment
+
+The install directory is self-contained but your shell does not know about it yet.
+ALPS provides a setup script that adds the right directories to `PATH`,
+`LD_LIBRARY_PATH`, and `PYTHONPATH`. Source it once before using ALPS:
+
+```ShellSession
+# bash / zsh:
+$ source </path/to/install/dir>/bin/alpsvars.sh
+
+# csh / tcsh:
+$ source </path/to/install/dir>/bin/alpsvars.csh
+```
+
+To avoid running this command in every new terminal session, add the `source` line
+to your shell's startup file (`~/.bashrc`, `~/.zshrc`, or `~/.cshrc`).
+
+**Verify the installation** by running one of the ALPS executables:
+
+```ShellSession
+$ spinmc --help
+```
+
+If the command is found and prints a help message, ALPS is installed and your
+environment is set up correctly.
 
 {{% /steps %}}
 

--- a/content/en/documentation/install/source.md
+++ b/content/en/documentation/install/source.md
@@ -206,12 +206,31 @@ The following combinations of `Boost`, Python and the C++ compiler have been tes
   For **NumPy ≥ 2.0**, `Boost` 1.87.0 or later is required for ALPS' Boost.Python bindings (CMake downloads this automatically).
 {{% /tab %}}
 {{% tab %}}
-ALPS has been tested on ARM-based MacOS systems using both the default compiler and the `Homebrew` gcc compiler (with `Boost` 1.86.0, NumPy < 2.0).
-On MacOS >=14.6 in order to successfully build ALPS using Homebrew gcc compiler, the following environment variable must be set:
+ALPS has been tested on ARM-based macOS systems using Apple's Xcode Clang and
+third-party compilers (Homebrew GCC, MacPorts GCC/Clang) with `Boost` 1.86.0+.
+
+**`SDKROOT` — when and how to set it**
+
+`SDKROOT` tells the compiler where to find macOS system headers and frameworks.
+Apple's own Clang (the `cc`/`c++` you get after installing Xcode or Command Line Tools)
+locates the SDK automatically — **you do not need to set `SDKROOT` when using Apple Clang**.
+
+Third-party compilers (Homebrew GCC, MacPorts GCC or LLVM Clang, etc.) do not know
+where the SDK lives and will fail with errors about missing system headers. Before
+running `cmake`, set:
 
 ```ShellSession
-export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/
+export SDKROOT=$(xcrun --show-sdk-path)
 ```
+
+`xcrun --show-sdk-path` always returns the correct path for whichever Xcode or
+Command Line Tools version you have installed, regardless of macOS version. Do not
+hardcode a version-specific path such as `MacOSX14.sdk` — it will break whenever
+Xcode is updated.
+
+To check which compiler CMake will use, look for the `C compiler identification` line
+at the start of the cmake output. If it says `AppleClang`, you do not need `SDKROOT`.
+If it says `GNU` or `Clang` (without "Apple"), set it as shown above.
 
 **Python selection:** On macOS, CMake searches Apple's framework paths before `$PATH`
 and will often select the Xcode-bundled Python 3.9

--- a/content/en/documentation/install/source.md
+++ b/content/en/documentation/install/source.md
@@ -151,8 +151,16 @@ $ python3 -c "import numpy, scipy; print('numpy', numpy.__version__, 'scipy', sc
 > for whichever Python CMake will use.
 
 ### Download and Build
-We can now proceed to download and build the `ALPS` library. <br>
-In the snippet below, please replace `/path/to/install/directory` with the actual directory on your system you want ALPS to be installed.
+We can now proceed to download and build the `ALPS` library.
+In the snippet below, replace `</path/to/install/dir>` with the directory where you want ALPS installed.
+
+> **Before you run these commands, note two expected pauses:**
+> 1. **`cmake` configuration (~1–3 min):** CMake silently downloads Boost 1.87 (~130 MB)
+>    during configuration. The terminal will produce no output for a minute or two while
+>    the download completes — this is normal, do not interrupt it.
+> 2. **`cmake --build` (5–20 min):** Compiling ALPS and Boost from source takes several
+>    minutes even with all CPU cores. The terminal will be busy printing compiler lines
+>    throughout — also normal.
 
   ```ShellSession
   $ git clone https://github.com/alpsim/ALPS alps-src
@@ -160,6 +168,7 @@ In the snippet below, please replace `/path/to/install/directory` with the actua
          -DCMAKE_INSTALL_PREFIX=</path/to/install/dir>                  \
          -DCMAKE_CXX_FLAGS="-DBOOST_NO_AUTO_PTR                         \
          -DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF"
+  # ^ Boost (~130 MB) is downloaded here; no output for 1-3 min is normal
   $ cmake --build alps-build -j$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
   $ cmake --build alps-build -t test
   ```
@@ -167,12 +176,9 @@ In the snippet below, please replace `/path/to/install/directory` with the actua
 > **`-j` controls parallel compilation.** The expression above automatically uses all
 > logical CPU cores on both Linux (`nproc`) and macOS (`sysctl -n hw.logicalcpu`).
 > You can also set the number manually, e.g. `-j 8` for 8 cores.
-> Building ALPS including Boost from source typically takes **5–20 minutes** depending
-> on your hardware; the terminal will be busy and that is normal.
 
-> **Boost is downloaded automatically.** If `Boost_SRC_DIR` is not set, CMake fetches
-> Boost 1.87 during configuration (requires internet access). To build offline or reuse a
-> previously extracted archive, pass the path explicitly:
+> **Offline or slow-connection build:** By default CMake fetches Boost 1.87 at configure
+> time. To avoid the download, extract the archive manually first and pass the path:
 > ```ShellSession
 > $ cmake -S alps-src -B alps-build                                     \
 >        -DCMAKE_INSTALL_PREFIX=</path/to/install/dir>                  \

--- a/content/en/documentation/install/source.md
+++ b/content/en/documentation/install/source.md
@@ -106,10 +106,25 @@ $ pip3 install numpy scipy
 ### Verify Dependencies
 
  ```ShellSession
-$ gcc -v #  must be >= 10.5.0
-$ cmake --version # must be >= 3.18
-$ mpirun --version # OpenMPI 4.0 or MPICH 4
+$ gcc -v              # must be >= 10.5.0
+$ cmake --version     # must be >= 3.18
+$ mpirun --version    # OpenMPI 4.0 or MPICH 4
+$ python3 --version   # must be >= 3.9
+$ python3 -c "import numpy, scipy; print('numpy', numpy.__version__, 'scipy', scipy.__version__)"
 ```
+
+> **macOS — which Python will CMake use?** CMake on macOS searches Apple's framework
+> paths before `$PATH`, so it may silently select the Xcode-bundled Python 3.9 even if
+> you have a newer Python installed via Homebrew or MacPorts. During `cmake` configuration,
+> look for a line like:
+> ```
+> -- Found Python: /path/to/python (found version "X.Y.Z")
+> ```
+> If the path or version is not what you expect, pin it explicitly by adding
+> `-DPython3_EXECUTABLE=/path/to/your/python3` to your `cmake` command.
+> Typical paths are `/opt/homebrew/bin/python3` (Homebrew) or
+> `/opt/local/bin/python3` (MacPorts). Make sure `numpy` and `scipy` are installed
+> for whichever Python CMake will use.
 
 ### Download and Build
 We can now proceed to download and build the `ALPS` library. <br>
@@ -140,7 +155,7 @@ In the snippet below, please replace `/path/to/install/directory` with the actua
 ### Troubleshooting
 <details>
 * **Need a different MPI or BLAS?**  <br> Substitute the package names above with your cluster's module (e.g. [Intel MKL/OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html), [AMD AOCL](https://www.amd.com/en/developer/aocl.html), etc). [Cmake](https://cmake.org/) is a build system that will find the locations of the above packages and generate compilation instructions in Makefiles.
-* **Python errors** <br> Ensure you are using Python 3.9 at a minimum. Note: some installations (e.g. macOS) use `pip3` instead of pip. Refer to the [python website](https://www.python.org/) for support in installing the correct version.
+* **Python errors** <br> Ensure Python ≥ 3.9 is installed and that `numpy` and `scipy` are installed for the same Python that CMake selects. On macOS, CMake may pick the Xcode-bundled Python rather than your Homebrew/MacPorts Python — check the `Found Python:` line in the CMake output and pin the interpreter with `-DPython3_EXECUTABLE=/path/to/python3` if needed (see the [Verify Dependencies](#verify-dependencies) step).
 * **MPI mismatch?**   <br> Ensure that CMake is using the same MPI version as `mpirun --version`
 * **Boost errors** <br> Building ALPS' Python bindings against NumPy ≥ 2.0 requires Boost ≥ 1.87 (NumPy 2.0 introduced API changes that only Boost 1.87+ handles). Boost 1.76–1.86 work only with NumPy < 2.0. See the [build notes](#build-notes) for tested compiler/Boost/Python combinations.
 
@@ -168,15 +183,27 @@ On MacOS >=14.6 in order to successfully build ALPS using Homebrew gcc compiler,
 export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/
 ```
 
-**Python selection:** CMake may pick up the Xcode system Python (3.9) rather than your
-Homebrew or MacPorts Python. If you see the wrong Python version during configuration,
-pin it explicitly:
+**Python selection:** On macOS, CMake searches Apple's framework paths before `$PATH`
+and will often select the Xcode-bundled Python 3.9
+(`/Applications/Xcode.app/.../python3.9`) even when a newer Python is installed via
+Homebrew or MacPorts and appears first in your shell. Verify which Python CMake
+found by looking for the `Found Python:` line printed during configuration. If it is not
+the one you want, pin it explicitly — do not rely on `$(which python3)` as it may still
+resolve to the wrong interpreter. Use the full path instead:
 
 ```ShellSession
-$ cmake -S alps-src -B alps-build \
-       ... \
-       -DPython3_EXECUTABLE=$(which python3)
+# Homebrew (Apple Silicon):
+$ cmake -S alps-src -B alps-build ... -DPython3_EXECUTABLE=/opt/homebrew/bin/python3
+
+# Homebrew (Intel):
+$ cmake -S alps-src -B alps-build ... -DPython3_EXECUTABLE=/usr/local/bin/python3
+
+# MacPorts:
+$ cmake -S alps-src -B alps-build ... -DPython3_EXECUTABLE=/opt/local/bin/python3
 ```
+
+Whichever Python CMake uses, make sure `numpy` and `scipy` are installed for it
+(`/path/to/that/python3 -m pip install numpy scipy`).
 
 {{% /tab %}}
 

--- a/content/en/documentation/install/source.md
+++ b/content/en/documentation/install/source.md
@@ -46,9 +46,17 @@ $ pip install numpy scipy # python libraries
 $ python3 -m pip install numpy scipy
 ```
 
-> **Note:** Do not install Boost via `apt`. ALPS builds Boost from source to ensure
-> ABI compatibility. CMake auto-downloads Boost 1.87 during configuration (requires
-> internet access). See the offline alternative in the build step below if needed.
+> **Do not install Boost via `apt`.** ALPS must compile Boost from source for two reasons:
+> 1. **Custom compiler flags** — ALPS requires `-DBOOST_NO_AUTO_PTR` and
+>    `-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF` for C++17/20 compatibility; the
+>    `libboost-dev` packages do not set these, causing link errors.
+> 2. **Python-ABI match** — the `Boost.Python` component must be compiled against the
+>    exact Python interpreter that ALPS will use. Pre-built packages target the system
+>    Python and will silently mismatch if you use a different one.
+>
+> CMake handles both automatically: it downloads and compiles Boost 1.87 during
+> configuration (requires internet access). See the offline alternative in the build
+> step below if needed.
 </details>
 <details>
 <summary><strong> macOS (via Homebrew)</strong> </summary>
@@ -62,9 +70,17 @@ $ brew install cmake hdf5 \
 $ pip3 install numpy scipy
 ```
 
-> **Note:** Do not install Boost via Homebrew. ALPS builds Boost from source to ensure
-> ABI compatibility. If `Boost_SRC_DIR` is not set, CMake auto-downloads Boost 1.87
-> during configuration (requires internet access). Alternatively, download it manually:
+> **Do not install Boost via Homebrew.** ALPS must compile Boost from source for two reasons:
+> 1. **Custom compiler flags** — ALPS requires `-DBOOST_NO_AUTO_PTR` and
+>    `-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF` for C++17/20 compatibility; the
+>    Homebrew `boost` formula does not set these, causing link errors.
+> 2. **Python-ABI match** — the `Boost.Python` component must be compiled against the
+>    exact Python interpreter that ALPS will use. The Homebrew Boost targets Homebrew's
+>    own Python and will silently mismatch any other interpreter.
+>
+> CMake handles both automatically: if `Boost_SRC_DIR` is not set, it downloads and
+> compiles Boost 1.87 during configuration (requires internet access). To build offline
+> or reuse a previously extracted archive, download it manually first:
 > ```ShellSession
 > $ curl -LO https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz
 > $ tar -xzf boost_1_87_0.tar.gz
@@ -94,9 +110,17 @@ $ pip3 install numpy scipy
 > The `port select` step is required: without it, the bare `mpirun`, `mpicc`, and
 > `mpicxx` wrappers that CMake looks for will not exist.
 
-> **Note:** Do not install Boost via MacPorts. ALPS builds Boost from source to ensure
-> ABI compatibility. If `Boost_SRC_DIR` is not set, CMake auto-downloads Boost 1.87
-> during configuration (requires internet access). Alternatively, download it manually:
+> **Do not install Boost via MacPorts.** ALPS must compile Boost from source for two reasons:
+> 1. **Custom compiler flags** — ALPS requires `-DBOOST_NO_AUTO_PTR` and
+>    `-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF` for C++17/20 compatibility; the
+>    MacPorts `boost` ports do not set these, causing link errors.
+> 2. **Python-ABI match** — the `Boost.Python` component must be compiled against the
+>    exact Python interpreter that ALPS will use. MacPorts Boost targets MacPorts' own
+>    Python and will silently mismatch any other interpreter.
+>
+> CMake handles both automatically: if `Boost_SRC_DIR` is not set, it downloads and
+> compiles Boost 1.87 during configuration (requires internet access). To build offline
+> or reuse a previously extracted archive, download it manually first:
 > ```ShellSession
 > $ curl -LO https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz
 > $ tar -xzf boost_1_87_0.tar.gz

--- a/content/en/documentation/install/source.md
+++ b/content/en/documentation/install/source.md
@@ -136,9 +136,15 @@ In the snippet below, please replace `/path/to/install/directory` with the actua
          -DCMAKE_INSTALL_PREFIX=</path/to/install/dir>                  \
          -DCMAKE_CXX_FLAGS="-DBOOST_NO_AUTO_PTR                         \
          -DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF"
-  $ cmake --build alps-build -j 8
+  $ cmake --build alps-build -j$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
   $ cmake --build alps-build -t test
   ```
+
+> **`-j` controls parallel compilation.** The expression above automatically uses all
+> logical CPU cores on both Linux (`nproc`) and macOS (`sysctl -n hw.logicalcpu`).
+> You can also set the number manually, e.g. `-j 8` for 8 cores.
+> Building ALPS including Boost from source typically takes **5–20 minutes** depending
+> on your hardware; the terminal will be busy and that is normal.
 
 > **Boost is downloaded automatically.** If `Boost_SRC_DIR` is not set, CMake fetches
 > Boost 1.87 during configuration (requires internet access). To build offline or reuse a

--- a/content/en/documentation/install/source.md
+++ b/content/en/documentation/install/source.md
@@ -70,6 +70,38 @@ $ pip3 install numpy scipy
 > $ tar -xzf boost_1_87_0.tar.gz
 > ```
 </details>
+<details>
+<summary><strong> macOS (via MacPorts)</strong> </summary>
+
+```ShellSession
+$ sudo port selfupdate
+$ sudo port install cmake \
+                   hdf5 \
+                   OpenBLAS \
+                   openmpi-clang20   # see note below about choosing a variant
+$ sudo port select --set mpi openmpi-clang20-fortran
+
+# install Python libs:
+$ pip3 install numpy scipy
+```
+
+> **Choosing an OpenMPI variant:** MacPorts ships a separate port for each compiler
+> version, named `openmpi-<compiler><version>` (e.g. `openmpi-clang20`,
+> `openmpi-gcc15`). The `clang20` variant shown above matches the LLVM Clang 20 port
+> and works alongside Apple's Xcode clang. If you use a different compiler, install the
+> matching variant and adjust the `port select` command accordingly.
+>
+> The `port select` step is required: without it, the bare `mpirun`, `mpicc`, and
+> `mpicxx` wrappers that CMake looks for will not exist.
+
+> **Note:** Do not install Boost via MacPorts. ALPS builds Boost from source to ensure
+> ABI compatibility. If `Boost_SRC_DIR` is not set, CMake auto-downloads Boost 1.87
+> during configuration (requires internet access). Alternatively, download it manually:
+> ```ShellSession
+> $ curl -LO https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz
+> $ tar -xzf boost_1_87_0.tar.gz
+> ```
+</details>
 
 ### Verify Dependencies
 

--- a/content/ja/documentation/install/source.md
+++ b/content/ja/documentation/install/source.md
@@ -20,7 +20,7 @@ ALPSはいくつかの外部ライブラリに依存しています。<br>
 | HDF5     | 1.10.0 | `libhdf5-dev` |
 | CMake | 3.18 | `cmake` |
 | C++ コンパイラ | GCC 10.5.0 または Clang 13.0.1 | `build-essential` |
-| Boost | 1.76 <br>*(NumPy ≥ 2.0 の場合は 1.87 が必要)* | 下記参照 |
+| Boost | 1.76 <br>*(NumPy ≥ 2.0 向けに ALPS Python バインディングをビルドする場合は 1.87 が必要)* | 下記参照 |
 | MPI | OpenMPI 4.0 **または** MPICH 4.0 | `libopenmpi-dev` / `libmpich-dev` |
 | BLAS | 0.3 | `libopenblas-dev` |
 | Python | 3.9 | [python.org](https://www.python.org/) |
@@ -46,7 +46,7 @@ $ python3 -m pip install numpy scipy
 
 > **`apt`でBoostをインストールしないでください。** ALPSはBoostをソースからコンパイルする必要があります。理由は2つあります：
 > 1. **カスタムコンパイラフラグ** — ALPSはC++17/20互換性のために`-DBOOST_NO_AUTO_PTR`と`-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF`を必要としますが、`libboost-dev`パッケージはこれらを設定しないため、リンクエラーが発生します。
-> 2. **Python ABIの一致** — `Boost.Python`コンポーネントはALPSが使用するPythonインタープリタと全く同じものに対してコンパイルされる必要があります。パッケージマネージャーのビルドはシステムPythonを対象としており、異なるインタープリタと一致しない場合があります。
+> 2. **Python ABIの一致** — `Boost.Python`コンポーネントはALPSが使用するPythonインタープリタと全く同じものに対してコンパイルされる必要があります。パッケージマネージャーのビルドはシステムPythonを対象としており、別のインタープリタを使うと、警告なしにABIが一致しなくなることがあります。
 >
 > CMakeは両方を自動的に処理します：`Boost_SRC_DIR`が設定されていない場合、設定時にBoost 1.87をダウンロードしてコンパイルします（インターネット接続が必要）。オフラインビルドの代替については、ビルドステップを参照してください。
 </details>
@@ -65,7 +65,7 @@ $ pip3 install numpy scipy
 
 > **HomebrewでBoostをインストールしないでください。** ALPSはBoostをソースからコンパイルする必要があります。理由は2つあります：
 > 1. **カスタムコンパイラフラグ** — ALPSはC++17/20互換性のために`-DBOOST_NO_AUTO_PTR`と`-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF`を必要としますが、Homebrewの`boost`フォーミュラはこれらを設定しないため、リンクエラーが発生します。
-> 2. **Python ABIの一致** — `Boost.Python`コンポーネントはALPSが使用するPythonインタープリタと全く同じものに対してコンパイルされる必要があります。HomebrewのBoostはHomebrew独自のPythonを対象としており、他のインタープリタと一致しない場合があります。
+> 2. **Python ABIの一致** — `Boost.Python`コンポーネントはALPSが使用するPythonインタープリタと全く同じものに対してコンパイルされる必要があります。HomebrewのBoostはHomebrew独自のPythonを対象としており、別のインタープリタを使うと、警告なしにABIが一致しなくなることがあります。
 >
 > CMakeは両方を自動的に処理します：`Boost_SRC_DIR`が設定されていない場合、設定時にBoost 1.87をダウンロードしてコンパイルします（インターネット接続が必要）。オフラインビルドまたは既存のアーカイブを使用する場合は、手動でダウンロードしてください：
 > ```ShellSession
@@ -91,11 +91,11 @@ $ pip3 install numpy scipy
 
 > **OpenMPIバリアントの選択:** MacPortsはコンパイラバージョンごとに個別のポートを提供します（`openmpi-<compiler><version>`の形式、例：`openmpi-clang20`、`openmpi-gcc15`）。上記の`clang20`バリアントはLLVM Clang 20ポートに対応しており、XcodeのApple Clangと共存できます。異なるコンパイラを使用する場合は、対応するバリアントをインストールし、`port select`コマンドを適宜変更してください。
 >
-> `port select`ステップは必須です：これを実行しないと、CMakeが検索するベアの`mpirun`、`mpicc`、`mpicxx`ラッパーが存在しません。
+> `port select`ステップは必須です：これを実行しないと、CMakeが探す`mpirun`、`mpicc`、`mpicxx`を名前だけでは実行できません。
 
 > **MacPortsでBoostをインストールしないでください。** ALPSはBoostをソースからコンパイルする必要があります。理由は2つあります：
 > 1. **カスタムコンパイラフラグ** — ALPSはC++17/20互換性のために`-DBOOST_NO_AUTO_PTR`と`-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF`を必要としますが、MacPortsの`boost`ポートはこれらを設定しないため、リンクエラーが発生します。
-> 2. **Python ABIの一致** — `Boost.Python`コンポーネントはALPSが使用するPythonインタープリタと全く同じものに対してコンパイルされる必要があります。MacPortsのBoostはMacPorts独自のPythonを対象としており、他のインタープリタと一致しない場合があります。
+> 2. **Python ABIの一致** — `Boost.Python`コンポーネントはALPSが使用するPythonインタープリタと全く同じものに対してコンパイルされる必要があります。MacPortsのBoostはMacPorts独自のPythonを対象としており、別のインタープリタを使うと、警告なしにABIが一致しなくなることがあります。
 >
 > CMakeは両方を自動的に処理します：`Boost_SRC_DIR`が設定されていない場合、設定時にBoost 1.87をダウンロードしてコンパイルします（インターネット接続が必要）。オフラインビルドまたは既存のアーカイブを使用する場合は、手動でダウンロードしてください：
 > ```ShellSession
@@ -125,8 +125,8 @@ $ python3 -c "import numpy, scipy; print('numpy', numpy.__version__, 'scipy', sc
 ALPSライブラリのダウンロードとビルドを開始します。
 以下のコマンドでは、`</path/to/install/dir>`を実際のインストールディレクトリに置き換えてください。
 
-> **これらのコマンドを実行する前に、2つの待機が予想されることを確認してください：**
-> 1. **`cmake`設定（約1〜3分）：** CMakeは設定時にBoost 1.87（約130 MB）を暗黙的にダウンロードします。ダウンロード完了まで1〜2分間ターミナルに出力が表示されませんが、これは正常です。中断しないでください。
+> **これらのコマンドを実行する前に、次の2か所で待ち時間が発生することに注意してください：**
+> 1. **`cmake`設定（約1〜3分）：** CMakeは設定時にBoost 1.87（約130 MB）を自動的にダウンロードします。ダウンロード完了まで1〜2分間ターミナルに出力が表示されませんが、これは正常です。中断しないでください。
 > 2. **`cmake --build`（5〜20分）：** ALPSとBoostをソースからコンパイルするには、全CPUコアを使用しても数分かかります。ターミナルはコンパイラの出力で埋め尽くされます — これも正常です。
 
 ```ShellSession
@@ -157,7 +157,7 @@ $ cmake --build alps-build -t test
 * **別のMPI/BLASが必要ですか？** <br> 上記のパッケージ名をクラスタのモジュール（例: [Intel MKL/OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html), [AMD AOCL](https://www.amd.com/en/developer/aocl.html), 等）に置き換えてください。[CMake](https://cmake.org/)はこれらのパッケージの位置を自動検出し、Makefileにコンパイル指示を生成します。
 * **Pythonエラー** <br> Python ≥ 3.9がインストールされており、CMakeが選択したPythonと同じものに`numpy`と`scipy`がインストールされていることを確認してください。macOSでは、CMakeがHomebrew/MacPortsのPythonではなくXcodeに同梱されたPythonを選択することがあります。CMake出力の`Found Python:`行を確認し、必要に応じて`-DPython3_EXECUTABLE=/path/to/python3`でインタープリタを指定してください（[依存関係の確認](#依存関係の確認)ステップを参照）。
 * **MPIのバージョン不一致？** <br> CMakeが使用するMPIバージョンが`mpirun --version`の結果と一致していることを確認してください。
-* **Boostエラー** <br> NumPy ≥ 2.0に対してALPSのPythonバインディングをビルドする場合はBoost ≥ 1.87が必要です（NumPy 2.0で導入されたAPIの変更はBoost 1.87以降のみが対応しています）。Boost 1.76〜1.86はNumPy < 2.0でのみ動作します。テスト済みの組み合わせについてはビルド注意事項を参照してください。
+* **Boostエラー** <br> NumPy ≥ 2.0に対してALPSのPythonバインディングをビルドする場合はBoost ≥ 1.87が必要です（NumPy 2.0で導入されたAPIの変更はBoost 1.87以降のみが対応しています）。Boost 1.76〜1.86はNumPy < 2.0でのみ動作します。テスト済みの組み合わせについては[ビルド注意事項](#ビルド注意事項)を参照してください。
 
 </details>
 
@@ -173,7 +173,7 @@ $ cmake --build alps-build -t test
   - Clang 14.0.0, Python 3.10.14 (NumPy < 2.0), Boost 1.81.0, 1.86.0
   - Clang 15.0.7, Python 3.10.14 (NumPy < 2.0), Boost 1.81.0, 1.86.0
 
-  **NumPy ≥ 2.0** の場合、ALPSのBoost.PythonバインディングにはBoost 1.87.0以降が必要です（CMakeが自動でダウンロードします）。
+  **NumPy ≥ 2.0** 向けに ALPS Python バインディングをビルドする場合は、Boost 1.87.0以降が必要です（CMakeが自動でダウンロードします）。
 {{% /tab %}}
 {{% tab %}}
 ALPSはARMベースのmacOSシステムで、Apple XcodeのClangとサードパーティコンパイラ（Homebrew GCC、MacPorts GCC/Clang）でBoost 1.86.0以降を使用してテスト済みです。
@@ -229,7 +229,7 @@ $ cmake --install alps-build
 
 ### 環境設定
 
-インストールディレクトリは自己完結していますが、シェルはその場所をまだ認識していません。ALPSは`PATH`、`LD_LIBRARY_PATH`、`PYTHONPATH`に適切なディレクトリを追加するセットアップスクリプトを提供しています。ALPSを使用する前に一度ソースとして読み込んでください：
+インストール先のディレクトリに必要なファイルがすべて含まれていますが、まだシェルからは認識されていません。ALPSは`PATH`、`LD_LIBRARY_PATH`、`PYTHONPATH`に適切なパスを追加するセットアップスクリプトを提供しています。ALPSを使用する前に一度 source コマンドで読み込んでください：
 
 ```ShellSession
 # bash / zsh:

--- a/content/ja/documentation/install/source.md
+++ b/content/ja/documentation/install/source.md
@@ -20,17 +20,17 @@ ALPSはいくつかの外部ライブラリに依存しています。<br>
 | HDF5     | 1.10.0 | `libhdf5-dev` |
 | CMake | 3.18 | `cmake` |
 | C++ コンパイラ | GCC 10.5.0 または Clang 13.0.1 | `build-essential` |
-| Boost | 1.76 <br>*(NumPy ≥ 2.0 / Python ≥ 3.13 の場合は 1.87)* | 下記参照 |
+| Boost | 1.76 <br>*(NumPy ≥ 2.0 の場合は 1.87 が必要)* | 下記参照 |
 | MPI | OpenMPI 4.0 **または** MPICH 4.0 | `libopenmpi-dev` / `libmpich-dev` |
 | BLAS | 0.3 | `libopenblas-dev` |
 | Python | 3.9 | [python.org](https://www.python.org/) |
 
 
 <br>
-      
+
 <details>
 <summary><strong> Ubuntu / Debian / WSL</strong> </summary>
- 
+
 ```ShellSession
 $ sudo apt update
 $ sudo apt install build-essential cmake \
@@ -39,108 +39,187 @@ $ sudo apt install build-essential cmake \
                    libopenmpi-dev openmpi-bin # または: libmpich-dev mpich
 
 # Pythonライブラリのインストール:
-$ pip install numpy scipy # Pythonライブラリ
+$ pip install numpy scipy
 # または
 $ python3 -m pip install numpy scipy
 ```
 
-> **注:** Boostは`apt`でインストールしないでください。ALPSはABI互換性を確保するためにBoostをソースからビルドします。CMakeが設定時にBoost 1.87を自動ダウンロードします（インターネット接続が必要）。
-</details> 
+> **`apt`でBoostをインストールしないでください。** ALPSはBoostをソースからコンパイルする必要があります。理由は2つあります：
+> 1. **カスタムコンパイラフラグ** — ALPSはC++17/20互換性のために`-DBOOST_NO_AUTO_PTR`と`-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF`を必要としますが、`libboost-dev`パッケージはこれらを設定しないため、リンクエラーが発生します。
+> 2. **Python ABIの一致** — `Boost.Python`コンポーネントはALPSが使用するPythonインタープリタと全く同じものに対してコンパイルされる必要があります。パッケージマネージャーのビルドはシステムPythonを対象としており、異なるインタープリタと一致しない場合があります。
+>
+> CMakeは両方を自動的に処理します：`Boost_SRC_DIR`が設定されていない場合、設定時にBoost 1.87をダウンロードしてコンパイルします（インターネット接続が必要）。オフラインビルドの代替については、ビルドステップを参照してください。
+</details>
 
-<details> <summary><strong> macOS (Homebrew経由)</strong> </summary>
+<details>
+<summary><strong> macOS (Homebrew経由)</strong> </summary>
 
-```
+```ShellSession
 $ brew update
 $ brew install cmake hdf5 \
                openblas open-mpi # または: mpich
 
 # Pythonライブラリのインストール:
-$ pip3 install numpy scipy 
+$ pip3 install numpy scipy
 ```
 
-> **注:** HomebrewでBoostをインストールしないでください。CMakeが設定時にBoost 1.87を自動ダウンロードします（インターネット接続が必要）。
+> **HomebrewでBoostをインストールしないでください。** ALPSはBoostをソースからコンパイルする必要があります。理由は2つあります：
+> 1. **カスタムコンパイラフラグ** — ALPSはC++17/20互換性のために`-DBOOST_NO_AUTO_PTR`と`-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF`を必要としますが、Homebrewの`boost`フォーミュラはこれらを設定しないため、リンクエラーが発生します。
+> 2. **Python ABIの一致** — `Boost.Python`コンポーネントはALPSが使用するPythonインタープリタと全く同じものに対してコンパイルされる必要があります。HomebrewのBoostはHomebrew独自のPythonを対象としており、他のインタープリタと一致しない場合があります。
+>
+> CMakeは両方を自動的に処理します：`Boost_SRC_DIR`が設定されていない場合、設定時にBoost 1.87をダウンロードしてコンパイルします（インターネット接続が必要）。オフラインビルドまたは既存のアーカイブを使用する場合は、手動でダウンロードしてください：
+> ```ShellSession
+> $ curl -LO https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz
+> $ tar -xzf boost_1_87_0.tar.gz
+> ```
+</details>
+
+<details>
+<summary><strong> macOS (MacPorts経由)</strong> </summary>
+
+```ShellSession
+$ sudo port selfupdate
+$ sudo port install cmake \
+                   hdf5 \
+                   OpenBLAS \
+                   openmpi-clang20   # バリアントの選択については下記参照
+$ sudo port select --set mpi openmpi-clang20-fortran
+
+# Pythonライブラリのインストール:
+$ pip3 install numpy scipy
+```
+
+> **OpenMPIバリアントの選択:** MacPortsはコンパイラバージョンごとに個別のポートを提供します（`openmpi-<compiler><version>`の形式、例：`openmpi-clang20`、`openmpi-gcc15`）。上記の`clang20`バリアントはLLVM Clang 20ポートに対応しており、XcodeのApple Clangと共存できます。異なるコンパイラを使用する場合は、対応するバリアントをインストールし、`port select`コマンドを適宜変更してください。
+>
+> `port select`ステップは必須です：これを実行しないと、CMakeが検索するベアの`mpirun`、`mpicc`、`mpicxx`ラッパーが存在しません。
+
+> **MacPortsでBoostをインストールしないでください。** ALPSはBoostをソースからコンパイルする必要があります。理由は2つあります：
+> 1. **カスタムコンパイラフラグ** — ALPSはC++17/20互換性のために`-DBOOST_NO_AUTO_PTR`と`-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF`を必要としますが、MacPortsの`boost`ポートはこれらを設定しないため、リンクエラーが発生します。
+> 2. **Python ABIの一致** — `Boost.Python`コンポーネントはALPSが使用するPythonインタープリタと全く同じものに対してコンパイルされる必要があります。MacPortsのBoostはMacPorts独自のPythonを対象としており、他のインタープリタと一致しない場合があります。
+>
+> CMakeは両方を自動的に処理します：`Boost_SRC_DIR`が設定されていない場合、設定時にBoost 1.87をダウンロードしてコンパイルします（インターネット接続が必要）。オフラインビルドまたは既存のアーカイブを使用する場合は、手動でダウンロードしてください：
+> ```ShellSession
+> $ curl -LO https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz
+> $ tar -xzf boost_1_87_0.tar.gz
+> ```
 </details>
 
 ### 依存関係の確認
+
+```ShellSession
+$ gcc -v              # 10.5.0以上である必要あり
+$ cmake --version     # 3.18以上である必要あり
+$ mpirun --version    # OpenMPI 4.0 または MPICH 4
+$ python3 --version   # 3.9以上である必要あり
+$ python3 -c "import numpy, scipy; print('numpy', numpy.__version__, 'scipy', scipy.__version__)"
 ```
-$ gcc -v # 10.5.0以上である必要あり
-$ cmake --version # 3.18以上である必要あり
-$ mpirun --version # OpenMPI 4.0 または MPICH 4
-```
+
+> **macOS — CMakeはどのPythonを使用しますか？** macOS上のCMakeはAppleのフレームワークパスを`$PATH`より先に検索するため、HomebrewやMacPortsに新しいPythonがインストールされていても、Xcodeに同梱されたPython 3.9を暗黙的に選択することがあります。`cmake`設定時に以下のような行を探してください：
+> ```
+> -- Found Python: /path/to/python (found version "X.Y.Z")
+> ```
+> パスまたはバージョンが期待通りでない場合は、`cmake`コマンドに`-DPython3_EXECUTABLE=/path/to/your/python3`を追加して明示的に指定してください。典型的なパスは`/opt/homebrew/bin/python3`（Homebrew）または`/opt/local/bin/python3`（MacPorts）です。CMakeが使用するPythonに`numpy`と`scipy`がインストールされていることを確認してください。
 
 ### ダウンロードとビルド
 
 ALPSライブラリのダウンロードとビルドを開始します。
-以下のコマンドでは、/path/to/install/directoryを実際のインストールディレクトリに置き換えてください。
+以下のコマンドでは、`</path/to/install/dir>`を実際のインストールディレクトリに置き換えてください。
 
-```
+> **これらのコマンドを実行する前に、2つの待機が予想されることを確認してください：**
+> 1. **`cmake`設定（約1〜3分）：** CMakeは設定時にBoost 1.87（約130 MB）を暗黙的にダウンロードします。ダウンロード完了まで1〜2分間ターミナルに出力が表示されませんが、これは正常です。中断しないでください。
+> 2. **`cmake --build`（5〜20分）：** ALPSとBoostをソースからコンパイルするには、全CPUコアを使用しても数分かかります。ターミナルはコンパイラの出力で埋め尽くされます — これも正常です。
+
+```ShellSession
 $ git clone https://github.com/alpsim/ALPS alps-src
 $ cmake -S alps-src -B alps-build                                     \
-         -DCMAKE_INSTALL_PREFIX=</path/to/install/dir>                  \
-         -DCMAKE_CXX_FLAGS="-DBOOST_NO_AUTO_PTR                         \
-         -DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF"
-$ cmake --build alps-build -j 8
+       -DCMAKE_INSTALL_PREFIX=</path/to/install/dir>                  \
+       -DCMAKE_CXX_FLAGS="-DBOOST_NO_AUTO_PTR                         \
+       -DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF"
+# ^ Boost（約130 MB）がここでダウンロードされます。1〜3分間出力がないのは正常です
+$ cmake --build alps-build -j$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
 $ cmake --build alps-build -t test
 ```
 
-### ビデオチュートリアル
+> **`-j`は並列コンパイル数を制御します。** 上記の式はLinux（`nproc`）とmacOS（`sysctl -n hw.logicalcpu`）の両方で全論理CPUコアを自動的に使用します。手動で設定することも可能です（例：8コアの場合は`-j 8`）。
 
-{{< youtube id="OHQGfDDaRMk" >}}
+> **オフラインまたは低速接続でのビルド：** デフォルトではCMakeが設定時にBoost 1.87をダウンロードします。ダウンロードを回避するには、先にアーカイブを手動で展開し、パスを指定してください：
+> ```ShellSession
+> $ cmake -S alps-src -B alps-build                                     \
+>        -DCMAKE_INSTALL_PREFIX=</path/to/install/dir>                  \
+>        -DBoost_SRC_DIR=</path/to/boost_1_87_0>                        \
+>        -DCMAKE_CXX_FLAGS="-DBOOST_NO_AUTO_PTR                         \
+>        -DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF"
+> ```
 
-<details> 
-<summary><strong>トラブルシューティング</strong></summary>
-* **別のMPI/BLASが必要ですか？**
-上記のパッケージ名をクラスタのモジュール（例: [Intel MKL/OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html), [AMD AOCL](https://www.amd.com/en/developer/aocl.html), 等）に置き換えてください。[CMake](https://cmake.org/)はこれらのパッケージの位置を自動検出し、Makefileにコンパイル指示を生成します。
+### トラブルシューティング
+<details>
 
-* **Pythonエラー**
-Python 3.9以上を使用していることを確認してください。注意：一部の環境（macOSなど）ではpipの代わりにpip3を使用します。正しいバージョンのインストールサポートについては[Python](https://www.python.org/)公式サイトを参照してください。
-
-* **MPIのバージョン不一致？**
-CMakeが使用するMPIバージョンがmpirun --versionの結果と一致していることを確認してください。
-
-* **Boostエラー**
-ALPSのPythonバインディングをNumPy ≥ 2.0に対してビルドする場合はBoost ≥ 1.87が必要です。Boost 1.76〜1.86はNumPy < 2.0でのみ動作します（テスト済みの組み合わせについてはビルド注意事項を参照）。
+* **別のMPI/BLASが必要ですか？** <br> 上記のパッケージ名をクラスタのモジュール（例: [Intel MKL/OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html), [AMD AOCL](https://www.amd.com/en/developer/aocl.html), 等）に置き換えてください。[CMake](https://cmake.org/)はこれらのパッケージの位置を自動検出し、Makefileにコンパイル指示を生成します。
+* **Pythonエラー** <br> Python ≥ 3.9がインストールされており、CMakeが選択したPythonと同じものに`numpy`と`scipy`がインストールされていることを確認してください。macOSでは、CMakeがHomebrew/MacPortsのPythonではなくXcodeに同梱されたPythonを選択することがあります。CMake出力の`Found Python:`行を確認し、必要に応じて`-DPython3_EXECUTABLE=/path/to/python3`でインタープリタを指定してください（[依存関係の確認](#依存関係の確認)ステップを参照）。
+* **MPIのバージョン不一致？** <br> CMakeが使用するMPIバージョンが`mpirun --version`の結果と一致していることを確認してください。
+* **Boostエラー** <br> NumPy ≥ 2.0に対してALPSのPythonバインディングをビルドする場合はBoost ≥ 1.87が必要です（NumPy 2.0で導入されたAPIの変更はBoost 1.87以降のみが対応しています）。Boost 1.76〜1.86はNumPy < 2.0でのみ動作します。テスト済みの組み合わせについてはビルド注意事項を参照してください。
 
 </details>
 
 #### ビルド注意事項
+
 {{% tabs items="Linux,Mac" %}}
 {{% tab %}}
 以下のBoost、Python、C++コンパイラの組み合わせがテスト済みです：
-- GCC 10.5.0, Python 3.9.19 (NumPy < 2.0), Boost 1.76.0
+  - GCC 10.5.0, Python 3.9.19 (NumPy < 2.0), Boost 1.76.0
+  - GCC 11.4.0, Python 3.10.14 (NumPy < 2.0), Boost 1.81.0, 1.86.0
+  - GCC 12.3.0, Python 3.10.14 (NumPy < 2.0), Boost 1.81.0, 1.86.0
+  - Clang 13.0.1, Python 3.10.14 (NumPy < 2.0), Boost 1.81.0, 1.86.0
+  - Clang 14.0.0, Python 3.10.14 (NumPy < 2.0), Boost 1.81.0, 1.86.0
+  - Clang 15.0.7, Python 3.10.14 (NumPy < 2.0), Boost 1.81.0, 1.86.0
 
-- GCC 11.4.0, Python 3.10.14 (NumPy < 2.0), Boost 1.81.0, 1.86.0
-
-- GCC 12.3.0, Python 3.10.14 (NumPy < 2.0), Boost 1.81.0, 1.86.0
-
-- Clang 13.0.1, Python 3.10.14 (NumPy < 2.0), Boost 1.81.0, 1.86.0
-
-- Clang 14.0.0, Python 3.10.14 (NumPy < 2.0), Boost 1.81.0, 1.86.0
-
-- Clang 15.0.7, Python 3.10.14 (NumPy < 2.0), Boost 1.81.0, 1.86.0
-
-**NumPy ≥ 2.0** の場合、ALPSのBoost.PythonバインディングにはBoost 1.87.0以降が必要です（CMakeが自動でダウンロードします）。
+  **NumPy ≥ 2.0** の場合、ALPSのBoost.PythonバインディングにはBoost 1.87.0以降が必要です（CMakeが自動でダウンロードします）。
 {{% /tab %}}
 {{% tab %}}
+ALPSはARMベースのmacOSシステムで、Apple XcodeのClangとサードパーティコンパイラ（Homebrew GCC、MacPorts GCC/Clang）でBoost 1.86.0以降を使用してテスト済みです。
 
-ALPSはARMベースのMacOSシステムで、デフォルトコンパイラとHomebrewのgccコンパイラ（Boost 1.86.0、NumPy < 2.0使用）の両方でテスト済みです。
-MacOS ≥14.6でHomebrew gccコンパイラを使用してALPSをビルドする場合、以下の環境変数を設定する必要があります：
+**`SDKROOT` — いつ、どのように設定するか**
 
+`SDKROOT`はコンパイラにmacOSシステムヘッダーとフレームワークの場所を伝えます。
+AppleのClang（XcodeまたはCommand Line Toolsのインストール後に利用できる`cc`/`c++`）はSDKを自動的に見つけます — **Apple Clangを使用する場合は`SDKROOT`を設定する必要はありません**。
+
+サードパーティコンパイラ（Homebrew GCC、MacPorts GCCまたはLLVM Clangなど）はSDKの場所を知らないため、システムヘッダーが見つからないというエラーでビルドが失敗します。`cmake`を実行する前に以下を設定してください：
+
+```ShellSession
+export SDKROOT=$(xcrun --show-sdk-path)
 ```
-export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/
+
+`xcrun --show-sdk-path`は、インストールされているXcodeまたはCommand Line Toolsのバージョンに関わらず、常に正しいパスを返します。macOSのバージョンが更新されるたびに壊れる`MacOSX14.sdk`のようなバージョン固有のパスをハードコーディングしないでください。
+
+CMakeが使用するコンパイラを確認するには、cmake出力の最初にある`C compiler identification`の行を確認してください。`AppleClang`と表示されている場合は`SDKROOT`は不要です。`GNU`または`Clang`（"Apple"なし）と表示されている場合は上記のように設定してください。
+
+**Pythonの選択:** macOS上のCMakeはAppleのフレームワークパスを`$PATH`より先に検索するため、HomebrewやMacPortsに新しいPythonがインストールされていても、Xcodeに同梱されたPython 3.9（`/Applications/Xcode.app/.../python3.9`）を選択することがあります。設定時に出力される`Found Python:`行でCMakeが見つけたPythonを確認してください。期待するものでない場合は、`$(which python3)`に頼らず（依然として間違ったインタープリタを指す可能性があるため）、フルパスを使用して明示的に指定してください：
+
+```ShellSession
+# Homebrew（Apple Silicon）:
+$ cmake -S alps-src -B alps-build ... -DPython3_EXECUTABLE=/opt/homebrew/bin/python3
+
+# Homebrew（Intel）:
+$ cmake -S alps-src -B alps-build ... -DPython3_EXECUTABLE=/usr/local/bin/python3
+
+# MacPorts:
+$ cmake -S alps-src -B alps-build ... -DPython3_EXECUTABLE=/opt/local/bin/python3
 ```
+
+CMakeが使用するPythonに`numpy`と`scipy`がインストールされていることを確認してください（`/path/to/that/python3 -m pip install numpy scipy`）。
+
 {{% /tab %}}
+
 {{% /tabs %}}
 
-ステップ1で依存パッケージを非標準の場所にインストールした場合、CMakeがパッケージを見つけられない可能性があります。ALPSは標準のCMakeメカニズム（FindXXX.cmake）を使用してパッケージを検索します。以下の情報が役立つ場合があります：
-
+依存パッケージを非標準の場所にインストールした場合、CMakeがパッケージを見つけられない可能性があります。ALPSは標準のCMakeメカニズム（FindXXX.cmake）を使用してパッケージを検索します。以下の情報が役立つ場合があります：
   - MPI: [CMake MPIドキュメント](https://cmake.org/cmake/help/latest/module/FindMPI.html)
   - BLAS: [CMake BLASドキュメント](https://cmake.org/cmake/help/latest/module/FindBLAS.html)
   - HDF5: [CMake HDF5ドキュメント](https://cmake.org/cmake/help/latest/module/FindHDF5.html)
 
 ***
 
-コードのビルドに成功したら、インストールを実行する必要があります。インストール先は設定時に-DCMAKE_INSTALL_PREFIX=/path/to/install/directoryパラメータで指定します。または、インストール段階で--prefixパラメータに新しいパスを明示的に指定することも可能です（[CMakeマニュアル参照](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake--install-0)）。
+コードのビルドに成功したら、インストールを実行する必要があります。インストール先は設定時に`-DCMAKE_INSTALL_PREFIX=/path/to/install/directory`パラメータで指定します。または、インストール段階で`--prefix`パラメータに新しいパスを明示的に指定することも可能です（[CMakeマニュアル参照](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake--install-0)）。
 
 インストールコマンド：
 
@@ -148,7 +227,31 @@ export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/
 $ cmake --install alps-build
 ```
 
-インストールディレクトリが作成されます。すべてが正常に完了した場合、インストールパスのbinディレクトリにspinmcやfulldiagなどのALPS実行ファイルが見つかります。
+### 環境設定
+
+インストールディレクトリは自己完結していますが、シェルはその場所をまだ認識していません。ALPSは`PATH`、`LD_LIBRARY_PATH`、`PYTHONPATH`に適切なディレクトリを追加するセットアップスクリプトを提供しています。ALPSを使用する前に一度ソースとして読み込んでください：
+
+```ShellSession
+# bash / zsh:
+$ source </path/to/install/dir>/bin/alpsvars.sh
+
+# csh / tcsh:
+$ source </path/to/install/dir>/bin/alpsvars.csh
+```
+
+すべてのターミナルセッションでこのコマンドを実行しなくて済むように、`source`行をシェルのスタートアップファイル（`~/.bashrc`、`~/.zshrc`、または`~/.cshrc`）に追加してください。
+
+**インストールの確認** — ALPSの実行ファイルのいずれかを実行してください：
+
+```ShellSession
+$ spinmc --help
+```
+
+コマンドが見つかりヘルプメッセージが表示されれば、ALPSのインストールと環境設定は正常に完了しています。
 
 {{% /steps %}}
 
+### ビデオチュートリアル
+<br>
+
+{{< youtube id="OHQGfDDaRMk" >}}

--- a/content/zh-cn/documentation/install/source.md
+++ b/content/zh-cn/documentation/install/source.md
@@ -20,16 +20,16 @@ ALPS 依赖多个外部库。
 | HDF5       | 1.10.0         | `libhdf5-dev`           |
 | CMake      | 3.18           | `cmake`                 |
 | C++ 编译器 | GCC 10.5.0 或 Clang 13.0.1 | `build-essential`      |
-| Boost      | 1.76 <br>*(若 NumPy ≥ 2.0 / Python ≥ 3.13 需 1.87)* | 见下文 |
+| Boost      | 1.76 <br>*(若 NumPy ≥ 2.0 需 1.87)* | 见下文 |
 | MPI        | OpenMPI 4.0 **或** MPICH 4.0 | `libopenmpi-dev` / `libmpich-dev` |
 | BLAS       | 0.3            | `libopenblas-dev`       |
 | Python     | 3.9            | [python.org](https://www.python.org/) |
 
 <br>
-      
+
 <details>
 <summary><strong> Ubuntu / Debian / WSL</strong> </summary>
- 
+
 ```ShellSession
 $ sudo apt update
 $ sudo apt install build-essential cmake \
@@ -38,16 +38,19 @@ $ sudo apt install build-essential cmake \
                    libopenmpi-dev openmpi-bin # 或: libmpich-dev mpich
 
 # 安装 Python 库:
-$ pip install numpy scipy # python 库
-
+$ pip install numpy scipy
 # 或
 $ python3 -m pip install numpy scipy
 ```
 
-> **注意:** 请勿通过 `apt` 安装 Boost。ALPS 从源码构建 Boost 以确保 ABI 兼容性。CMake 在配置时会自动下载 Boost 1.87（需要网络连接）。
-</details> 
+> **请勿通过 `apt` 安装 Boost。** ALPS 必须从源码编译 Boost，原因有二：
+> 1. **自定义编译器标志** — ALPS 需要 `-DBOOST_NO_AUTO_PTR` 和 `-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF` 以兼容 C++17/20；`libboost-dev` 软件包不设置这些标志，会导致链接错误。
+> 2. **Python ABI 匹配** — `Boost.Python` 组件必须针对 ALPS 使用的同一 Python 解释器进行编译。预构建软件包针对系统 Python，若使用其他解释器则会出现不匹配。
+>
+> CMake 会自动处理：若未设置 `Boost_SRC_DIR`，则在配置时下载并编译 Boost 1.87（需要网络连接）。如需离线构建，请参阅下方编译步骤中的替代方案。
+</details>
 
-<details> 
+<details>
 <summary><strong> macOS (通过 Homebrew)</strong> </summary>
 
 ```ShellSession
@@ -56,88 +59,191 @@ $ brew install cmake hdf5 \
                openblas open-mpi # 或: mpich
 
 # 安装 Python 库:
-$ pip3 install numpy scipy 
+$ pip3 install numpy scipy
 ```
 
-> **注意:** 请勿通过 Homebrew 安装 Boost。CMake 在配置时会自动下载 Boost 1.87（需要网络连接）。
+> **请勿通过 Homebrew 安装 Boost。** ALPS 必须从源码编译 Boost，原因有二：
+> 1. **自定义编译器标志** — ALPS 需要 `-DBOOST_NO_AUTO_PTR` 和 `-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF` 以兼容 C++17/20；Homebrew 的 `boost` formula 不设置这些标志，会导致链接错误。
+> 2. **Python ABI 匹配** — `Boost.Python` 组件必须针对 ALPS 使用的同一 Python 解释器进行编译。Homebrew Boost 针对 Homebrew 自带的 Python，与其他解释器会出现不匹配。
+>
+> CMake 会自动处理：若未设置 `Boost_SRC_DIR`，则在配置时下载并编译 Boost 1.87（需要网络连接）。如需离线构建或复用已解压的存档，请先手动下载：
+> ```ShellSession
+> $ curl -LO https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz
+> $ tar -xzf boost_1_87_0.tar.gz
+> ```
+</details>
+
+<details>
+<summary><strong> macOS (通过 MacPorts)</strong> </summary>
+
+```ShellSession
+$ sudo port selfupdate
+$ sudo port install cmake \
+                   hdf5 \
+                   OpenBLAS \
+                   openmpi-clang20   # 请参阅下方关于选择变体的说明
+$ sudo port select --set mpi openmpi-clang20-fortran
+
+# 安装 Python 库:
+$ pip3 install numpy scipy
+```
+
+> **选择 OpenMPI 变体：** MacPorts 为每个编译器版本提供独立的端口，命名为 `openmpi-<compiler><version>`（例如 `openmpi-clang20`、`openmpi-gcc15`）。上示的 `clang20` 变体对应 LLVM Clang 20 端口，可与 Xcode 的 Apple Clang 共存。若使用不同编译器，请安装对应变体并相应调整 `port select` 命令。
+>
+> `port select` 步骤是必须的：若不执行此步骤，CMake 搜索的裸 `mpirun`、`mpicc`、`mpicxx` 包装器将不存在。
+
+> **请勿通过 MacPorts 安装 Boost。** ALPS 必须从源码编译 Boost，原因有二：
+> 1. **自定义编译器标志** — ALPS 需要 `-DBOOST_NO_AUTO_PTR` 和 `-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF` 以兼容 C++17/20；MacPorts 的 `boost` 端口不设置这些标志，会导致链接错误。
+> 2. **Python ABI 匹配** — `Boost.Python` 组件必须针对 ALPS 使用的同一 Python 解释器进行编译。MacPorts Boost 针对 MacPorts 自带的 Python，与其他解释器会出现不匹配。
+>
+> CMake 会自动处理：若未设置 `Boost_SRC_DIR`，则在配置时下载并编译 Boost 1.87（需要网络连接）。如需离线构建或复用已解压的存档，请先手动下载：
+> ```ShellSession
+> $ curl -LO https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz
+> $ tar -xzf boost_1_87_0.tar.gz
+> ```
 </details>
 
 ### 验证依赖项
+
+```ShellSession
+$ gcc -v              # 必须 ≥ 10.5.0
+$ cmake --version     # 必须 ≥ 3.18
+$ mpirun --version    # 需为 OpenMPI 4.0 或 MPICH 4
+$ python3 --version   # 必须 ≥ 3.9
+$ python3 -c "import numpy, scipy; print('numpy', numpy.__version__, 'scipy', scipy.__version__)"
 ```
-$ gcc -v # 必须 ≥ 10.5.0
-$ cmake --version # 必须 ≥ 3.18
-$ mpirun --version # 需为 OpenMPI 4.0 或 MPICH 4
-```
+
+> **macOS — CMake 将使用哪个 Python？** macOS 上的 CMake 在搜索 `$PATH` 之前会先搜索 Apple 的框架路径，即使通过 Homebrew 或 MacPorts 安装了更新版本的 Python，也可能默认选择 Xcode 自带的 Python 3.9。在 `cmake` 配置时，请查找如下输出行：
+> ```
+> -- Found Python: /path/to/python (found version "X.Y.Z")
+> ```
+> 若路径或版本不符合预期，请在 `cmake` 命令中添加 `-DPython3_EXECUTABLE=/path/to/your/python3` 显式指定。典型路径为 `/opt/homebrew/bin/python3`（Homebrew）或 `/opt/local/bin/python3`（MacPorts）。请确保 CMake 使用的 Python 已安装 `numpy` 和 `scipy`。
 
 ### 下载与编译
-现在可以下载并编译 ALPS 库：
 
-在以下命令中，请将 `/path/to/install/directory` 替换为您系统的实际安装目录。
-```
+现在可以下载并编译 ALPS 库。在以下命令中，请将 `</path/to/install/dir>` 替换为您系统的实际安装目录。
+
+> **运行这些命令之前，请注意以下两个预期等待：**
+> 1. **`cmake` 配置（约 1–3 分钟）：** CMake 在配置时会静默下载 Boost 1.87（约 130 MB）。下载完成前终端将无任何输出，等待一两分钟是正常的，请勿中断。
+> 2. **`cmake --build`（5–20 分钟）：** 即使使用全部 CPU 核心，从源码编译 ALPS 和 Boost 也需要数分钟。终端将持续打印编译输出——这也是正常现象。
+
+```ShellSession
 $ git clone https://github.com/alpsim/ALPS alps-src
-$ cmake -S alps-src -B alps-build \
-         -DCMAKE_INSTALL_PREFIX=</path/to/install/dir> \
-         -DCMAKE_CXX_FLAGS="-DBOOST_NO_AUTO_PTR \
-         -DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF"
-$ cmake --build alps-build -j 8
+$ cmake -S alps-src -B alps-build                                     \
+       -DCMAKE_INSTALL_PREFIX=</path/to/install/dir>                  \
+       -DCMAKE_CXX_FLAGS="-DBOOST_NO_AUTO_PTR                         \
+       -DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF"
+# ^ Boost（约 130 MB）在此处下载；1–3 分钟内无输出属正常
+$ cmake --build alps-build -j$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
 $ cmake --build alps-build -t test
 ```
 
-<details> 
-<summary><strong>故障排除</strong></summary>
+> **`-j` 控制并行编译数。** 上述表达式在 Linux（`nproc`）和 macOS（`sysctl -n hw.logicalcpu`）上均可自动使用全部逻辑 CPU 核心。也可手动指定，如 8 核时使用 `-j 8`。
 
-* **需使用其他 MPI/BLAS?**
-将上述包名替换为您集群的模块 (如 [Intel MKL/OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html), [AMD AOCL](https://www.amd.com/en/developer/aocl.html), 等)。[CMake](https://cmake.org/) 会自动定位这些包并生成编译指令。
+> **离线或低速连接构建：** 默认情况下 CMake 在配置时下载 Boost 1.87。如需避免下载，请先手动解压存档并指定路径：
+> ```ShellSession
+> $ cmake -S alps-src -B alps-build                                     \
+>        -DCMAKE_INSTALL_PREFIX=</path/to/install/dir>                  \
+>        -DBoost_SRC_DIR=</path/to/boost_1_87_0>                        \
+>        -DCMAKE_CXX_FLAGS="-DBOOST_NO_AUTO_PTR                         \
+>        -DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF"
+> ```
 
-* **Python 错误**
-确保使用 Python 3.9 或更高版本。注意：部分系统 (如 macOS) 使用 pip3 而非 pip。请参考 [Python 官网](https://www.python.org/) 获取安装支持。
+### 故障排除
+<details>
 
-* **MPI 版本不匹配?**
-确保 CMake 使用的 MPI 版本与 mpirun --version 一致。
-
-* **Boost 错误**
-使用 NumPy ≥ 2.0 构建 ALPS Python 绑定需要 Boost ≥ 1.87；Boost 1.76–1.86 仅支持 NumPy < 2.0。不同编译器与 Python 版本的支持组合请参考构建说明。
+* **需使用其他 MPI/BLAS？** <br> 将上述包名替换为您集群的模块（如 [Intel MKL/OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html), [AMD AOCL](https://www.amd.com/en/developer/aocl.html) 等）。[CMake](https://cmake.org/) 会自动定位这些包并生成编译指令。
+* **Python 错误** <br> 请确保 Python ≥ 3.9 已安装，且 `numpy` 和 `scipy` 安装在 CMake 所选的同一 Python 下。在 macOS 上，CMake 可能选择 Xcode 自带的 Python 而非 Homebrew/MacPorts 的 Python——请检查 CMake 输出中的 `Found Python:` 行，必要时使用 `-DPython3_EXECUTABLE=/path/to/python3` 指定解释器（参见[验证依赖项](#验证依赖项)步骤）。
+* **MPI 版本不匹配？** <br> 确保 CMake 使用的 MPI 版本与 `mpirun --version` 一致。
+* **Boost 错误** <br> 针对 NumPy ≥ 2.0 构建 ALPS Python 绑定需要 Boost ≥ 1.87（NumPy 2.0 引入的 API 变更仅 Boost 1.87+ 支持）。Boost 1.76–1.86 仅支持 NumPy < 2.0。已测试的编译器/Boost/Python 组合请参阅编译说明。
 
 </details>
 
 #### 编译说明
+
 {{% tabs items="Linux,Mac" %}}
 {{% tab %}}
 以下 Boost、Python 和 C++ 编译器的组合已通过测试：
-  - GCC 10.5.0, Python 3.9.19 (NumPy < 2.0) and `Boost` 1.76.0
-  - GCC 11.4.0, Python 3.10.14 (NumPy < 2.0) and `Boost` 1.81.0, 1.86.0
-  - GCC 12.3.0, Python 3.10.14 (NumPy < 2.0) and `Boost` 1.81.0, 1.86.0
-  - Clang 13.0.1, Python 3.10.14 (NumPy < 2.0) and `Boost` 1.81.0, 1.86.0
-  - Clang 14.0.0, Python 3.10.14 (NumPy < 2.0) and `Boost` 1.81.0, 1.86.0
-  - Clang 15.0.7, Python 3.10.14 (NumPy < 2.0) and `Boost` 1.81.0, 1.86.0
+  - GCC 10.5.0, Python 3.9.19 (NumPy < 2.0), `Boost` 1.76.0
+  - GCC 11.4.0, Python 3.10.14 (NumPy < 2.0), `Boost` 1.81.0, 1.86.0
+  - GCC 12.3.0, Python 3.10.14 (NumPy < 2.0), `Boost` 1.81.0, 1.86.0
+  - Clang 13.0.1, Python 3.10.14 (NumPy < 2.0), `Boost` 1.81.0, 1.86.0
+  - Clang 14.0.0, Python 3.10.14 (NumPy < 2.0), `Boost` 1.81.0, 1.86.0
+  - Clang 15.0.7, Python 3.10.14 (NumPy < 2.0), `Boost` 1.81.0, 1.86.0
 
   **NumPy ≥ 2.0** 时，ALPS 的 Boost.Python 绑定需要 Boost 1.87.0 或更高版本（CMake 自动下载）。
 {{% /tab %}}
 {{% tab %}}
-ALPS 已在 ARM 架构的 MacOS 系统上通过默认编译器和 Homebrew 的 gcc 编译器 (使用 Boost 1.86.0，NumPy < 2.0) 完成测试。
-在 MacOS ≥14.6 系统中，若要通过 Homebrew gcc 成功构建 ALPS，需设置以下环境变量：
+ALPS 已在 ARM 架构的 macOS 系统上通过 Apple Xcode Clang 和第三方编译器（Homebrew GCC、MacPorts GCC/Clang）使用 Boost 1.86.0+ 完成测试。
+
+**`SDKROOT` — 何时以及如何设置**
+
+`SDKROOT` 告知编译器 macOS 系统头文件和框架的位置。Apple 的 Clang（安装 Xcode 或 Command Line Tools 后可用的 `cc`/`c++`）会自动定位 SDK——**使用 Apple Clang 时无需设置 `SDKROOT`**。
+
+第三方编译器（Homebrew GCC、MacPorts GCC 或 LLVM Clang 等）无法自动找到 SDK，会因缺少系统头文件而构建失败。运行 `cmake` 之前，请设置：
+
 ```ShellSession
-export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/
+export SDKROOT=$(xcrun --show-sdk-path)
 ```
+
+`xcrun --show-sdk-path` 无论安装了哪个版本的 Xcode 或 Command Line Tools，始终返回正确路径。请勿硬编码类似 `MacOSX14.sdk` 的版本特定路径——每次 Xcode 更新后都会失效。
+
+要检查 CMake 将使用哪个编译器，请查看 cmake 输出开头的 `C compiler identification` 行。若显示 `AppleClang`，无需设置 `SDKROOT`；若显示 `GNU` 或 `Clang`（不含"Apple"），请按上述方式设置。
+
+**Python 选择：** macOS 上的 CMake 在搜索 `$PATH` 之前会先搜索 Apple 框架路径，即使通过 Homebrew 或 MacPorts 安装了更新版本的 Python，也常会选择 Xcode 自带的 Python 3.9（`/Applications/Xcode.app/.../python3.9`）。请通过配置时输出的 `Found Python:` 行确认 CMake 找到的 Python。若不符合预期，请显式指定——不要依赖 `$(which python3)`，因为它仍可能指向错误的解释器。请使用完整路径：
+
+```ShellSession
+# Homebrew（Apple Silicon）:
+$ cmake -S alps-src -B alps-build ... -DPython3_EXECUTABLE=/opt/homebrew/bin/python3
+
+# Homebrew（Intel）:
+$ cmake -S alps-src -B alps-build ... -DPython3_EXECUTABLE=/usr/local/bin/python3
+
+# MacPorts:
+$ cmake -S alps-src -B alps-build ... -DPython3_EXECUTABLE=/opt/local/bin/python3
+```
+
+无论 CMake 使用哪个 Python，请确保该 Python 已安装 `numpy` 和 `scipy`（`/path/to/that/python3 -m pip install numpy scipy`）。
 
 {{% /tab %}}
 
 {{% /tabs %}}
 
-若依赖包安装在非标准路径，CMake 可能无法定位。ALPS 使用标准 CMake 机制 (FindXXX.cmake) 定位包，可参考：
-  - For MPI: 参考[cmake with mpi](https://cmake.org/cmake/help/latest/module/FindMPI.html)
-  - For BLAS: 参考 [cmake with BLAS](https://cmake.org/cmake/help/latest/module/FindBLAS.html)
-  - For HDF5: 参考 [cmake with HDF5](https://cmake.org/cmake/help/latest/module/FindHDF5.html)
+若依赖包安装在非标准路径，CMake 可能无法定位。ALPS 使用标准 CMake 机制（FindXXX.cmake）定位包，可参考：
+  - MPI: 参考 [cmake with mpi](https://cmake.org/cmake/help/latest/module/FindMPI.html)
+  - BLAS: 参考 [cmake with BLAS](https://cmake.org/cmake/help/latest/module/FindBLAS.html)
+  - HDF5: 参考 [cmake with HDF5](https://cmake.org/cmake/help/latest/module/FindHDF5.html)
 
 ***
 
-成功编译后需执行安装。安装路径由配置时的 -DCMAKE_INSTALL_PREFIX=/path/to/install/directory 参数指定，也可在安装阶段通过 --prefix 参数修改 (参见 [cmake manual](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake--install-0)).
+成功编译后需执行安装。安装路径由配置时的 `-DCMAKE_INSTALL_PREFIX=/path/to/install/directory` 参数指定，也可在安装阶段通过 `--prefix` 参数修改（参见 [cmake manual](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake--install-0)）。
 <br>
 运行安装命令：
-  ```ShellSession
-  $ cmake --install alps-build
-  ```
-安装目录将被创建。若一切顺利，您可在安装路径的 bin 目录下找到 ALPS 可执行文件 (如 mc 或 fulldiag)。
+
+```ShellSession
+$ cmake --install alps-build
+```
+
+### 配置环境
+
+安装目录是自包含的，但您的 shell 尚不知晓其位置。ALPS 提供了一个设置脚本，可将正确目录添加到 `PATH`、`LD_LIBRARY_PATH` 和 `PYTHONPATH`。使用 ALPS 前请先加载该脚本：
+
+```ShellSession
+# bash / zsh:
+$ source </path/to/install/dir>/bin/alpsvars.sh
+
+# csh / tcsh:
+$ source </path/to/install/dir>/bin/alpsvars.csh
+```
+
+为避免每次打开新终端都需执行此命令，请将 `source` 行添加到 shell 启动文件（`~/.bashrc`、`~/.zshrc` 或 `~/.cshrc`）中。
+
+**验证安装** — 运行任一 ALPS 可执行文件：
+
+```ShellSession
+$ spinmc --help
+```
+
+若命令可找到并打印帮助信息，则 ALPS 安装和环境配置均已成功。
 
 {{% /steps %}}
-


### PR DESCRIPTION
## Summary

Addresses eight gaps in the source installation guide identified by working through the build process from scratch on macOS with MacPorts. Changes are all in `content/en/documentation/install/source.md`.

- **MacPorts instructions** — add a collapsible macOS (via MacPorts) section with correct port names (`cmake`, `hdf5`, `OpenBLAS`, `openmpi-clang20`), the required `port select --set mpi` step (without it the bare `mpirun`/`mpicxx` wrappers CMake searches for do not exist), and guidance on choosing the right OpenMPI compiler variant.
- **Python selection ambiguity** — explain that CMake on macOS searches Apple framework paths before `$PATH` and silently picks Xcode Python 3.9; add a `python3 --version` + numpy/scipy check to Verify Dependencies; expand the Mac Build notes with full-path `-DPython3_EXECUTABLE` examples for Homebrew (Apple Silicon/Intel) and MacPorts; improve the Troubleshooting Python entry.
- **`-j` flag** — replace hard-coded `-j 8` with `$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)` (works on both Linux and macOS automatically); add a note explaining what `-j` does.
- **Boost from-source rationale** — expand all three platform notes (apt, Homebrew, MacPorts) to explain the two concrete reasons: custom compiler flags that packaged builds omit, and the Boost.Python/Python-ABI match requirement.
- **SDKROOT guidance** — rewrite the Mac Build notes SDKROOT section: explain that Apple Clang does not need it; replace the hardcoded `MacOSX14.sdk` path with `$(xcrun --show-sdk-path)` (version-independent); add a tip to check the `C compiler identification` cmake output line to know whether SDKROOT is needed at all.
- **Boost download warning** — add an upfront numbered callout before the build commands warning about two expected silent pauses (configure ~1–3 min for the Boost download, build 5–20 min for compilation); add an inline comment in the code block at the cmake line where the download happens.
- **Post-install environment setup** — add a new "Set up your environment" step explaining that `alpsvars.sh` / `alpsvars.csh` must be sourced to add the install directory to `PATH`, `LD_LIBRARY_PATH`, and `PYTHONPATH`; advise adding the source line to the shell startup file; end with `spinmc --help` as a concrete smoke-test.

## Test plan

- [ ] Render the page locally and check all three platform `<details>` blocks expand correctly
- [ ] Verify the MacPorts commands against a MacPorts installation
- [ ] Check the `xcrun --show-sdk-path` command on macOS
- [ ] Confirm `spinmc --help` works after a fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)