### PR TITLE
docs(mc07): fix heading hierarchy, pedagogy, and code clarity

### DIFF
--- a/content/en/tutorials/mcs/mc07.md
+++ b/content/en/tutorials/mcs/mc07.md
@@ -17,7 +17,7 @@ Extracting precise estimates requires long simulations, so we start the fine-gri
 
 Start the fine-grid simulations now so they run while you work through the rest of the tutorial.
 
-#### Setting up and running on the command line
+### Command line
 
 Download <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-07-phase-transition/parm7b" download>`parm7b`</a> and run:
 
@@ -26,7 +26,9 @@ parameter2xml parm7b
 spinmc --Tmin 10 parm7b.in.xml &
 ```
 
-#### Setting up and running in Python
+The `--Tmin 10` flag sets a checkpoint interval of 10 seconds, allowing the simulation to be safely interrupted and resumed.
+
+### Python
 
 The first part of <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-07-phase-transition/tutorial7b.py" download>`tutorial7b.py`</a> sets up and launches the same simulation:
 
@@ -61,7 +63,7 @@ pyalps.runApplication('spinmc', input_file, Tmin=5)
 
 We first make a coarse temperature scan on small systems to locate the critical region.
 
-#### Setting up and running on the command line
+### Command line
 
 Download <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-07-phase-transition/parm7a" download>`parm7a`</a> and run:
 
@@ -70,7 +72,7 @@ parameter2xml parm7a
 spinmc --Tmin 5 parm7a.in.xml
 ```
 
-#### Setting up and running in Python
+### Python
 
 Using <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-07-phase-transition/tutorial7a.py" download>`tutorial7a.py`</a>:
 
@@ -109,17 +111,17 @@ for l in [4, 8, 16]:
         )
 
 input_file = pyalps.writeInputFiles('parm7a', parms)
-pyalps.runApplication('spinmc', input_file, Tmin=5)
+pyalps.runApplication('spinmc', input_file, Tmin=5)  # Tmin: minimum wall time in seconds between checkpoints
 ```
 
 ### Magnetization, susceptibility, and specific heat
 
 The order parameter of the Ising transition is the magnetization per site $m$.
 On a finite system $\langle m \rangle = 0$ by symmetry, so we plot the average absolute value $\langle |m| \rangle$ instead.
-Load the results and plot it:
+Load the results and plot them:
 
 ```Python
-pyalps.evaluateSpinMC(pyalps.getResultFiles(prefix='parm7a'))
+pyalps.evaluateSpinMC(pyalps.getResultFiles(prefix='parm7a'))  # computes derived quantities (susceptibility, specific heat, Binder cumulant) from raw MC output
 data = pyalps.loadMeasurements(
     pyalps.getResultFiles(prefix='parm7a'),
     ['|Magnetization|', 'Connected Susceptibility', 'Specific Heat', 'Binder Cumulant', 'Binder Cumulant U2']
@@ -160,7 +162,10 @@ pyalps.plot.plot(spec_heat)
 plt.xlabel('Temperature $T$')
 plt.ylabel('Specific Heat $c_v$')
 plt.title('2D Ising model')
+plt.show()
 ```
+
+The specific heat peak near $T \approx 2.3$ grows only weakly with system size — much more slowly than the susceptibility — indicating that the exponent $\alpha$ is close to zero.
 
 ### Binder cumulant
 
@@ -178,10 +183,11 @@ pyalps.plot.plot(binder_u4)
 plt.xlabel('Temperature $T$')
 plt.ylabel('Binder Cumulant $U_4$')
 plt.title('2D Ising model')
+plt.show()
 ```
 
 From the crossing of the curves we can read off $T_c \in [2.2, 2.3]$.
-Another cumulant $U_2 = \langle m^2 \rangle / \langle |m| \rangle^2$ has the same crossing property and is left as an exercise.
+The second cumulant $U_2 = \langle m^2 \rangle / \langle |m| \rangle^2$ has the same crossing property; plotting it from the already-loaded `binder_u2` data is left as an exercise.
 
 ## Precise determination of $T_c$ and critical exponents
 
@@ -190,7 +196,7 @@ Using the finer temperature grid and larger system sizes from `parm7b`, we can e
 Load the results:
 
 ```Python
-pyalps.evaluateSpinMC(pyalps.getResultFiles(prefix='parm7b'))
+pyalps.evaluateSpinMC(pyalps.getResultFiles(prefix='parm7b'))  # computes derived quantities from raw MC output
 data = pyalps.loadMeasurements(
     pyalps.getResultFiles(prefix='parm7b'),
     ['|Magnetization|', 'Connected Susceptibility', 'Specific Heat', 'Binder Cumulant', 'Binder Cumulant U2']
@@ -380,7 +386,7 @@ for d in magnetization_abs:
 beta_over_nu = ...   # your estimate
 for d in magnetization_abs:
     l   = d.props['L']
-    d.y = d.y / pow(float(l), -beta_over_nu)
+    d.y = d.y / pow(float(l), -beta_over_nu)  # dividing by L^(-β/ν) = multiplying by L^(β/ν)
 
 plt.figure()
 pyalps.plot.plot(magnetization_abs)
@@ -397,7 +403,6 @@ The exact critical exponents of the 2D Ising model are
 $$\nu = 1, \quad \eta = \tfrac{1}{4}, \quad \beta = \tfrac{1}{8}, \quad \alpha = 0.$$
 
 For $\alpha = 0$: the specific heat diverges logarithmically rather than as a power law, so a power-law fit returns an exponent close to zero but not exactly zero.
-How do your numerical estimates compare with these exact values?
 
 For more precise estimates, fix the critical temperature to the exact value $T_c = 2/\ln(1+\sqrt{2}) \approx 2.2692$ and simulate larger system sizes.
 With $T_c$ fixed, a useful way to extract $\nu$ is via the derivative of the Binder cumulant.
@@ -407,6 +412,7 @@ The derivative can be obtained by numerical differentiation of the Monte Carlo d
 ## Questions
 
 - At what temperature do the Binder cumulant curves cross? How does your estimate compare with the exact value $T_c \approx 2.2692$?
+- How do your numerical estimates of $\nu$, $\eta$, $\beta$, and $\alpha$ compare with the exact values?
 - What value of $\nu$ do you extract from the Binder cumulant data collapse? Compare with the exact value $\nu = 1$.
 - The susceptibility peak grows strongly with system size while the specific heat peak grows much more slowly. What does this imply about $\alpha$?
 - Using $\gamma/\nu = 2 - \eta$, what value of $\eta$ do you obtain? Compare with the exact value $\eta = 1/4$.


### PR DESCRIPTION
## Summary

- **Headings**: Simplified "Setting up and running on the command line/Python" (####) to "Command line/Python" (###) throughout; hierarchy now consistent with the MC-08 overhaul (PR #60)
- **Pedagogy**: Added expected-outcome text after the specific heat plot; moved the inline comparison question into the Questions section; improved the U2 cumulant exercise note
- **Code clarity**: Explained `--Tmin`/`Tmin=5` (checkpoint interval); added inline comment explaining `pyalps.evaluateSpinMC`; clarified the double-negative in the `beta_over_nu` magnetization collapse
- **Bug fix**: Added `plt.show()` after the specific heat and Binder cumulant plots in the rough-scan section — without it, those figures never display when the script is run non-interactively
- **Grammar**: "plot it" -> "plot them"

## Test plan

- [ ] `hugo server` renders the page without errors
- [ ] All four rough-scan plots display when `tutorial7a.py` is run as a script
- [ ] Questions section contains the comparison question
- [ ] Heading hierarchy renders correctly in the sidebar TOC

Generated with [Claude Code](https://claude.com/claude-code)
