### PR TITLE
docs(mc05): fix heading hierarchy, Tmin inconsistency, and prose

### DIFF
--- a/content/en/tutorials/mcs/mc05.md
+++ b/content/en/tutorials/mcs/mc05.md
@@ -20,7 +20,7 @@ This tutorial uses the ALPS worm QMC code to locate this quantum phase transitio
 We first scan a wide range of hopping values on a $4 \times 4$ lattice to observe how the superfluid density $\rho_s$ (called "Stiffness" in ALPS) evolves across the transition.
 The Hilbert space is truncated at `Nmax=2` bosons per site, which is a good approximation near the Mott lobe at unit filling.
 
-#### Setting up and running on the command line
+### Command line
 
 The parameter file <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-05-bosons/parm5a" download>`parm5a`</a>:
 
@@ -54,7 +54,9 @@ parameter2xml parm5a
 worm --Tmin 10 --write-xml parm5a.in.xml
 ```
 
-#### Setting up and running in Python
+`--Tmin 10` sets the checkpoint interval to 10 seconds; `--write-xml` writes XML output files that pyalps can read alongside the HDF5 results.
+
+### Python
 
 The script <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-05-bosons/tutorial5a.py" download>`tutorial5a.py`</a>:
 
@@ -82,10 +84,10 @@ for t in [0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1]:
     )
 
 input_file = pyalps.writeInputFiles('parm5a', parms)
-pyalps.runApplication('worm', input_file, Tmin=5)
+pyalps.runApplication('worm', input_file, Tmin=10)
 ```
 
-#### Evaluating and plotting
+### Evaluating and plotting
 
 Load the superfluid stiffness and plot it as a function of hopping:
 
@@ -111,7 +113,7 @@ For $d=2$, $z=1$ this gives $\rho_s \sim L^{-1}$, so the combination $\rho_s L$ 
 
 We simulate three system sizes $L = 4, 6, 8$ on a fine grid of hopping values around the expected critical point.
 
-#### Setting up and running on the command line
+### Command line
 
 The parameter file <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-05-bosons/parm5b" download>`parm5b`</a>:
 
@@ -155,9 +157,9 @@ parameter2xml parm5b
 worm --Tmin 10 --write-xml parm5b.in.xml
 ```
 
-#### Setting up and running in Python
+### Python
 
-The script <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-05-bosons/tutorial5b.py" download>`tutorial5b.py`</a> adapts `tutorial5a.py`: rename the prefix to `parm5b`, lower `T` to 0.05, increase `THERMALIZATION` to 150000 and `SWEEPS` to 600000, and loop over both `L` and `t`:
+The script <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-05-bosons/tutorial5b.py" download>`tutorial5b.py`</a>:
 
 ```Python
 import pyalps
@@ -184,10 +186,10 @@ for L in [4, 6, 8]:
         )
 
 input_file = pyalps.writeInputFiles('parm5b', parms)
-pyalps.runApplication('worm', input_file, Tmin=5)
+pyalps.runApplication('worm', input_file, Tmin=10)
 ```
 
-#### Evaluating and plotting
+### Evaluating and plotting
 
 Load the stiffness for each system size, multiply by $L$, and plot:
 


### PR DESCRIPTION
## Summary

- **Heading hierarchy**: Promoted all `####` subsections to `###`; simplified text: "Setting up and running on the command line" → "Command line", "Setting up and running in Python" → "Python" — consistent with the MC-06/07/08 overhauls
- **`Tmin` inconsistency**: Both Python `runApplication` calls used `Tmin=5` while the command line examples used `--Tmin 10`; fixed to `Tmin=10` throughout
- **`--Tmin` / `--write-xml` explained**: Added a one-line note after the first command block explaining the checkpoint interval and why `--write-xml` is needed for pyalps
- **Redundant prose removed**: Removed the sentence in the parm5b Python section that re-narrated parameter changes already visible in the code

## Test plan

- [ ] `hugo server` renders the page without errors
- [ ] Heading hierarchy renders correctly in the sidebar TOC
- [ ] `Tmin=10` in both Python blocks matches `--Tmin 10` in command line blocks

Generated with [Claude Code](https://claude.com/claude-code)
