### PR TITLE
docs(mc04): fix heading hierarchy, Tmin inconsistency, missing imports

### DIFF
--- a/content/en/tutorials/mcs/mc04.md
+++ b/content/en/tutorials/mcs/mc04.md
@@ -18,7 +18,7 @@ The structure factor $S(\mathbf{q}) = \sum_\mathbf{r} e^{i\mathbf{q}\cdot\mathbf
 We simulate the $S = 1/2$ Heisenberg model on a $4 \times 4$ square lattice at temperature $T = 0.3$ with a small field $h = 0.1$ to weakly break the spin-rotation symmetry.
 The small system size allows a fast simulation; finite-size effects are significant at this scale.
 
-#### Setting up and running on the command line
+### Command line
 
 The parameter file <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-04-measurements/parm4" download>`parm4`</a> enables three additional measurement flags alongside the standard parameters:
 
@@ -49,7 +49,9 @@ parameter2xml parm4
 dirloop_sse --Tmin 10 --write-xml parm4.in.xml
 ```
 
-#### Setting up and running in Python
+`--Tmin 10` sets the checkpoint interval to 10 seconds; `--write-xml` writes XML output files that pyalps can read alongside the HDF5 results.
+
+### Python
 
 The script <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-04-measurements/tutorial4.py" download>`tutorial4.py`</a>:
 
@@ -73,10 +75,10 @@ parms = [{
 }]
 
 input_file = pyalps.writeInputFiles('parm4', parms)
-pyalps.runApplication('dirloop_sse', input_file, Tmin=5)
+pyalps.runApplication('dirloop_sse', input_file, Tmin=10)
 ```
 
-#### Evaluating the results
+### Evaluating the results
 
 Load all measurements from the output files and print them:
 
@@ -96,7 +98,7 @@ for s in pyalps.flatten(data):
 Scalar observables (energy, magnetization, susceptibility) are printed on a single line.
 Vector observables (correlations, structure factor, Green function) are printed one entry per line, with their index — site pair, wavevector, or imaginary-time point — shown alongside the value.
 
-#### Plotting the spin-spin correlations
+### Plotting the spin-spin correlations
 
 To visualize the correlation function, load the `Sz Correlations` observable and plot it:
 
@@ -118,9 +120,13 @@ plt.show()
 
 The correlations should alternate in sign with distance, with the nearest-neighbour value negative (antiferromagnetic) and its magnitude decreasing with $r$.
 
-#### Plotting the structure factor
+### Plotting the structure factor
 
 ```Python
+import pyalps
+import matplotlib.pyplot as plt
+import pyalps.plot
+
 data = pyalps.loadMeasurements(pyalps.getResultFiles(prefix='parm4'), 'Sz Structure Factor')
 structure_factor = pyalps.collectXY(data, x='q', y='Sz Structure Factor')
 


### PR DESCRIPTION
## Summary

- **Heading hierarchy**: Promoted all `####` subsections to `###`; simplified text: "Setting up and running on the command line" → "Command line", "Setting up and running in Python" → "Python" — consistent with MC-05/06/07/08 overhauls
- **Bug fix**: Added missing `import pyalps`, `import matplotlib.pyplot as plt`, and `import pyalps.plot` to the structure factor plotting block — without them the block fails if run standalone or after a fresh kernel
- **`Tmin` inconsistency**: Fixed `Tmin=5` → `Tmin=10` in the Python `runApplication` call to match `--Tmin 10` in the command line instructions
- **`--Tmin` / `--write-xml` explained**: Added a one-line note after the `dirloop_sse` command explaining the checkpoint interval and why `--write-xml` is needed

## Test plan

- [ ] `hugo server` renders the page without errors
- [ ] Structure factor plotting block runs standalone without import errors
- [ ] Heading hierarchy renders correctly in the sidebar TOC
- [ ] `Tmin=10` in Python block matches `--Tmin 10` in command line block

Generated with [Claude Code](https://claude.com/claude-code)
