### PR TITLE
docs: rewrite homepage package description (en, zh-cn, ja)

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -9,7 +9,7 @@ toc: true
 
 ## Welcome to the ALPS Software Package
 
-The ALPS (Algorithms and Libraries for Physics Simulations) software package aims to provide a set of well tested, robust, and standardized components for numerical simulations of condensed matter systems, including bosonic, fermionic, and spin systems. They consist of a set of components that are used in state-of-the-art high performance codes.
+ALPS (Algorithms and Libraries for Physics Simulations) is an open-source package for numerical simulations of quantum and classical condensed matter systems. It provides production-ready implementations of leading quantum algorithms for spin, bosonic, and fermionic lattice models. A Python interface and standardized file formats make it straightforward to set up simulations, run them on a laptop or HPC cluster, and analyse the results.
 
 <div class="cta-buttons" style="text-align:left;width:100%;">
 {{< cta-button text="Get started" link="documentation/start/intro" icon="build"  prim="yes" >}}

--- a/content/ja/_index.md
+++ b/content/ja/_index.md
@@ -9,7 +9,7 @@ toc: true
 
 ## ALPSソフトウェアパッケージへようこそ
 
-ALPS（Algorithms and Libraries for Physics Simulations）ソフトウェアパッケージは、ボソン系、フェルミオン系、スピン系を含む凝縮系物理システムの数値シミュレーション向けに、厳密にテストされた堅牢で標準化されたコンポーネントセットを提供することを目的としています。これらは最先端の高性能コードで使用されるコンポーネント群で構成されています。
+ALPS（Algorithms and Libraries for Physics Simulations）は、量子および古典的な凝縮系物理システムの数値シミュレーションのためのオープンソースパッケージです。スピン系・ボソン系・フェルミオン系の格子モデルに対応した最先端の量子アルゴリズムを、すぐに研究に使える形で実装しています。Pythonインターフェースと標準化されたファイル形式により、ノートパソコンからHPCクラスターまで、シミュレーションのセットアップ・実行・解析を手軽に行うことができます。
 
 <div class="cta-buttons" style="text-align:left;width:100%;">
 {{< cta-button text="はじめる" link="documentation/start/intro" icon="build"  prim="yes" >}}

--- a/content/zh-cn/_index.md
+++ b/content/zh-cn/_index.md
@@ -9,7 +9,7 @@ toc: true
 
 ## 欢迎使用 ALPS 软件包
 
-ALPS（物理模拟算法与程序库）软件包致力于为凝聚态系统（包括玻色子、费米子和自旋系统）的数值模拟提供经过充分测试、稳定且标准化的程序组件。这些程序组件构成了高性能代码的核心模块。
+ALPS（物理模拟算法与程序库）是一款面向量子和经典凝聚态系统数值模拟的开源软件包。它提供了适用于自旋、玻色子和费米子格点模型的一流量子算法的生产级实现。Python 接口与标准化文件格式使模拟的搭建、运行（笔记本电脑或高性能集群均可）以及结果分析变得简便高效。
 
 <div class="cta-buttons" style="text-align:left;width:100%;">
 {{< cta-button text="快速开始" link="documentation/start/intro" icon="build"  prim="yes" >}}


### PR DESCRIPTION
## Summary

Replaces the weak opening paragraph on the homepage in all three languages.

**Before (en):**
> The ALPS (Algorithms and Libraries for Physics Simulations) software package aims to provide a set of well tested, robust, and standardized components for numerical simulations of condensed matter systems, including bosonic, fermionic, and spin systems. They consist of a set of components that are used in state-of-the-art high performance codes.

**After (en):**
> ALPS (Algorithms and Libraries for Physics Simulations) is an open-source package for numerical simulations of quantum and classical condensed matter systems. It provides production-ready implementations of leading quantum algorithms for spin, bosonic, and fermionic lattice models. A Python interface and standardized file formats make it straightforward to set up simulations, run them on a laptop or HPC cluster, and analyse the results.

Changes:
- Removes hedging ("aims to provide")
- Cuts tautological second sentence ("they consist of components used in codes")
- Adds concrete selling points: open-source, Python interface, HPC-ready
- Synced to `zh-cn` and `ja`

## Test plan

- [ ] `hugo server` renders homepage without errors in all three languages
- [ ] English, Chinese, and Japanese descriptions are consistent in meaning

Generated with [Claude Code](https://claude.com/claude-code)
