### PR TITLE
fix: add limitations warning to ALPS chatbot

### DIFF
--- a/layouts/partials/chatbot.html
+++ b/layouts/partials/chatbot.html
@@ -15,7 +15,7 @@ html.dark pre.alps-diagram{background:#1a1a10!important;color:#d8d8c0!important}
     <div id="alps-chat-header">
       <div id="alps-chat-header-text">
         <span>ALPS Assistant</span>
-        <span id="alps-chat-subtitle">Ask me anything about ALPS</span>
+        <span id="alps-chat-subtitle">Keyword-based assistant &mdash; not AI</span>
       </div>
       <button id="alps-chat-close" aria-label="Close chat">&#x2715;</button>
     </div>
@@ -42,4 +42,4 @@ html.dark pre.alps-diagram{background:#1a1a10!important;color:#d8d8c0!important}
   </button>
 </div>
 
-<script src="/js/chatbot.js"></script>
+<script src="/js/chatbot.js?v=2"></script>

--- a/static/js/chatbot.js
+++ b/static/js/chatbot.js
@@ -2275,7 +2275,7 @@
       '<strong>generate simulation input files</strong> for you.<br><br>' +
       'Try: <em>"create a DMRG input file for a spin-1/2 chain L=32"</em><br>' +
       'or ask about installation, methods, models, tutorials, etc.<br><br>' +
-      '<small style="color:#888;line-height:1.4;display:block;margin-top:.25rem;">' +
+      '<small style="opacity:0.6;line-height:1.4;display:block;margin-top:.25rem;">' +
       '&#9888;&#xFE0E; This assistant uses keyword matching, not AI. It can only answer ' +
       'questions it was explicitly programmed for and may miss or misinterpret novel queries.' +
       '</small>',

--- a/static/js/chatbot.js
+++ b/static/js/chatbot.js
@@ -2274,7 +2274,11 @@
       'Hi! I\'m the ALPS assistant. I can answer questions about ALPS and ' +
       '<strong>generate simulation input files</strong> for you.<br><br>' +
       'Try: <em>"create a DMRG input file for a spin-1/2 chain L=32"</em><br>' +
-      'or ask about installation, methods, models, tutorials, etc.',
+      'or ask about installation, methods, models, tutorials, etc.<br><br>' +
+      '<small style="color:#888;line-height:1.4;display:block;margin-top:.25rem;">' +
+      '&#9888;&#xFE0E; This assistant uses keyword matching, not AI. It can only answer ' +
+      'questions it was explicitly programmed for and may miss or misinterpret novel queries.' +
+      '</small>',
       false);
 
     toggleBtn.addEventListener('click', function () {


### PR DESCRIPTION
## Summary

- Changes the chatbot header subtitle from "Ask me anything about ALPS" to "Keyword-based assistant — not AI"
- Adds a ⚠ disclaimer in the welcome message: *"This assistant uses keyword matching, not AI. It can only answer questions it was explicitly programmed for and may miss or misinterpret novel queries."*
- Bumps `chatbot.js` script tag to `?v=2` to bust browser cache on deploy

## Test plan

- [ ] Open the chatbot — subtitle should read "Keyword-based assistant — not AI"
- [ ] Welcome message should include the ⚠ disclaimer at the bottom
- [ ] Hard-refresh should not revert to old welcome message

🤖 Generated with [Claude Code](https://claude.ai/claude-code)