### PR TITLE
fix: lock homepage btn-grid to 3 columns on wide screens

### DIFF
--- a/assets/css/alps.css
+++ b/assets/css/alps.css
@@ -235,10 +235,22 @@
 
 .btn-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 0.75rem;
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
+}
+
+@media (max-width: 40rem) {
+  .btn-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 26rem) {
+  .btn-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .btn-grid .btn {


### PR DESCRIPTION
## Summary

- Replace `repeat(auto-fit, minmax(8rem, 1fr))` with a fixed `repeat(3, 1fr)` grid so the 3×3 navigation grid and 3×2 tutorial grid always render in three columns on wide screens, eliminating the ragged lone-button last row.
- Add two media-query step-downs: 2 columns at ≤ 640 px, 1 column at ≤ 416 px.

## Test plan

- [ ] Wide desktop (>640 px): both grids show exactly 3 columns
- [ ] Tablet/small laptop (~480–640 px): grids show 2 columns
- [ ] Phone portrait (<416 px): grids show 1 column

🤖 Generated with [Claude Code](https://claude.com/claude-code)