### PR TITLE
fix: restore visible label on language selector

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -81,6 +81,7 @@ languages:
           weight: 20
           params:
             type: language-switch
+            label: true
 
   zh-cn:
     label: 中文
@@ -146,6 +147,7 @@ languages:
           weight: 20
           params:
             type: language-switch
+            label: true
 
   ja:
     label: 日本語
@@ -211,6 +213,7 @@ languages:
           weight: 20
           params:
             type: language-switch
+            label: true
 
 module:
   hugoVersion:


### PR DESCRIPTION
## Summary

- The hextra v0.12.3 upgrade replaced the old custom navbar with the theme built-in language-switch partial, which defaults to icon-only (no label, no hover trigger).
- The small translate SVG alone was too easy to miss.
- Fix: add label: true to the language-switch menu params in all three language blocks (en, zh-cn, ja) in hugo.yaml.
- The button now shows the translate icon + current language name (English / 中文 / 日本語).

Only hugo.yaml is touched — no conflict risk with any open PR.

## Test plan

- [ ] Navbar shows translate icon + English label on the English site
- [ ] Navbar shows translate icon + 中文 on the Chinese site
- [ ] Navbar shows translate icon + 日本語 on the Japanese site
- [ ] Clicking the button opens the language dropdown with all three options

Generated with Claude Code