### PR TITLE
feat: rewrite FAQ page with improved content and action buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ resources
 public
 .idea
 go.sum
-.hugo_build.lockstatic/data/docs-index.json
+.hugo_build.lock
+static/data/docs-index.json

--- a/content/en/faqs/_index.md
+++ b/content/en/faqs/_index.md
@@ -5,24 +5,46 @@ weight: 8
 toc: false
 ---
 
-### How can I cite ALPS in my research publication?
+### I have a problem with ALPS and need help.
 
-Our software release publications are shown on [this page](../documentation/pubs/papers/). For specific numerical methods, please refer to our ["Code and Method References" page](../documentation/pubs/refs/). The citation requirement is discussed on the [citation page](../documentation/pubs/citations/).
+If you need help and you cannot find an answer on the webpage or in the documentation, you have two options. Either ask your question on Discord for immediate help, or file an issue under Issues. We will do our best to get back to you.
 
-### Where can I ask questions about ALPS installation, documentation, or tutorials?
+<div class="btn-grid">
+{{< cta-button text="Issues" link="https://github.com/ALPSim/ALPS/issues" icon="bug_report" >}}
+{{< cta-button text="Discord" link="https://discord.com/invite/JRNWnnva9g" icon="forum" >}}
+</div>
 
-We created a discord channel for community discussions. You can ask your questions in our [Github repository discussions](https://github.com/ALPSim/ALPS/discussions/categories/q-a) or in our [Discord channel](https://discord.com/invite/JRNWnnva9g).
+### What are the conditions for using ALPS?
+
+ALPS and all its applications are released under the [MIT License](https://github.com/ALPSim/ALPS/blob/main/LICENSE), one of the most permissive open-source licenses available. You are free to use, modify, and distribute ALPS in almost any context — including integrating it into your own software or using it in commercial projects — with minimal restrictions.
+
+If you find ALPS useful and publish scientific results obtained with it, we kindly ask that you cite our papers. Please visit our [publications page](../documentation/pubs/papers/) for the appropriate references.
 
 ### How can I report a bug in the codes?
 
-We encourage you to report the bug in the [issues section of our Github repository](https://github.com/ALPSim/ALPS/issues). The potential bug will be immediately investigated by one of our developers.
+If you have found a bug, please file an issue in our GitHub repository. When doing so, please follow the issue template provided on the GitHub page — this helps us reproduce and address the problem as efficiently as possible. You are also welcome to reach the ALPS team directly on Discord. We will do our best to investigate and respond promptly.
+
+<div class="btn-grid">
+{{< cta-button text="Issues" link="https://github.com/ALPSim/ALPS/issues" icon="bug_report" >}}
+{{< cta-button text="Discord" link="https://discord.com/invite/JRNWnnva9g" icon="forum" >}}
+</div>
 
 ### How can I install ALPS?
 
-Please follow the instructions on our [installation page](../install/) for Linux and Mac systems. Currently we do not support Windows system.
+Full installation instructions are available on our installation page. We support [binary](../install/binary/), [Spack](../install/spack/), and [source](../install/source/) installation.
+
+<div class="btn-grid">
+{{< cta-button text="Installation" link="../install/" icon="download" >}}
+</div>
 
 
 ### How can I contribute to ALPS?
 
-Please [contact](../govern#alps-community-steering-committee) one of our leaderships for further information. We will be happy to talk to you about your project.
-If you are a student and are interested in contributing to ALPS while you are in the process of learning about ALPS, we have an [onboarding statement](../govern/onboard/) for you.
+Contributions to ALPS are welcome at many levels — from taking on the maintenance of an existing code or contributing your own, to helping fix open issues and bugs. The first step is to reach out to our [Community Steering Committee](../govern#alps-community-steering-committee), who will be happy to discuss how your work can best fit into the project.
+
+Undergraduate students interested in getting involved with ALPS are encouraged to read our [Onboarding Statement for Students](../govern/onboard/).
+
+<div class="btn-grid">
+{{< cta-button text="Governance" link="../govern/" icon="account_balance" >}}
+{{< cta-button text="Issues" link="https://github.com/ALPSim/ALPS/issues" icon="bug_report" >}}
+</div>

--- a/content/ja/faqs/_index.md
+++ b/content/ja/faqs/_index.md
@@ -5,23 +5,45 @@ weight: 8
 toc: false
 ---
 
-### 研究論文でALPSを引用する方法は？
+### ALPSに問題が発生し、サポートが必要です。
 
-ソフトウェアリリース論文は[こちらのページ](../documentation/pubs/papers)に掲載しています。特定の数値手法については["コードと手法参考文献"ページ](../documentation/pubs/refs)をご参照ください。引用要件に関する詳細は[引用ガイドページ](../documentation/pubs/citations)で解説しています。
+ウェブページやドキュメントで解決策が見つからない場合は、2つの方法をご利用いただけます。すぐにサポートが必要な場合はDiscordでご質問いただくか、Issuesに問題を登録してください。できる限り迅速に対応いたします。
 
-### ALPSのインストール、ドキュメント、チュートリアルに関する質問はどこでできますか？
+<div class="btn-grid">
+{{< cta-button text="Issues" link="https://github.com/ALPSim/ALPS/issues" icon="bug_report" >}}
+{{< cta-button text="Discord" link="https://discord.com/invite/JRNWnnva9g" icon="forum" >}}
+</div>
 
-コミュニティディスカッション用にDiscordチャンネルを設けています。質問は[GitHubリポジトリのディスカッション](https://github.com/ALPSim/ALPS/discussions/categories/q-a)または[Discordチャンネル](https://discord.gg/JRNWnnva9g)でお受けしています。
+### ALPSの利用条件は何ですか？
+
+ALPSおよびそのすべてのアプリケーションは、[MITライセンス](https://github.com/ALPSim/ALPS/blob/main/LICENSE)のもとで公開されています。これは現在利用可能な最も寛容なオープンソースライセンスの一つです。自分のソフトウェアへの組み込みや商業利用を含む、ほぼあらゆる用途でALPSを自由に使用・改変・配布することができます。
+
+ALPSを活用して科学的な成果を発表される場合は、論文の引用をお願いいたします。適切な参考文献については[論文ページ](../documentation/pubs/papers/)をご覧ください。
 
 ### コードのバグを報告する方法は？
 
-[GitHubリポジトリのIssuesセクション](https://github.com/ALPSim/ALPS/issues)でバグ報告をお願いします。報告された潜在的なバグは、開発チームが直ちに調査します。
+バグを発見された場合は、GitHubリポジトリにIssueを登録してください。その際、GitHubページに用意されているIssueテンプレートに沿って記入いただくと、問題の再現と対応をより迅速に行うことができます。Discordから直接ALPSチームに連絡していただくことも歓迎します。できる限り速やかに調査・回答いたします。
+
+<div class="btn-grid">
+{{< cta-button text="Issues" link="https://github.com/ALPSim/ALPS/issues" icon="bug_report" >}}
+{{< cta-button text="Discord" link="https://discord.com/invite/JRNWnnva9g" icon="forum" >}}
+</div>
 
 ### ALPSのインストール方法は？
 
-LinuxおよびMacシステム向けのインストール手順は[インストールガイドページ](../install/)をご参照ください。現在Windowsシステムはサポートしておりません。
+詳細なインストール手順はインストールページをご覧ください。[バイナリ](../install/binary/)、[Spack](../install/spack/)、[ソース](../install/source/)の3種類のインストール方法に対応しています。
+
+<div class="btn-grid">
+{{< cta-button text="インストール" link="../install/" icon="download" >}}
+</div>
 
 ### ALPSへの貢献方法は？
 
-詳細については[運営委員会メンバー](../govern#alps-community-steering-committee)までお問い合わせください。プロジェクト内容について喜んでご相談させていただきます。
-学生の方でALPSの学習過程における貢献にご関心のある場合は、[オンボーディングステートメント](../govern/onboard)をご覧ください。
+ALPSへの貢献はさまざまなレベルで歓迎しています。既存コードのメンテナンスの引き受け、独自コードの提供、オープンなIssueやバグの修正など、多様な形での参加が可能です。まずは[コミュニティ運営委員会](../govern#alps-community-steering-committee)にご連絡ください。あなたの取り組みがプロジェクトにどのように貢献できるか、喜んでご相談いたします。
+
+ALPSへの参加に関心のある学部生の方は、[学生向けオンボーディングステートメント](../govern/onboard/)をぜひご覧ください。
+
+<div class="btn-grid">
+{{< cta-button text="ガバナンス" link="../govern/" icon="account_balance" >}}
+{{< cta-button text="Issues" link="https://github.com/ALPSim/ALPS/issues" icon="bug_report" >}}
+</div>

--- a/content/zh-cn/faqs/_index.md
+++ b/content/zh-cn/faqs/_index.md
@@ -5,23 +5,45 @@ weight: 8
 toc: false
 ---
 
-### 如何在研究论文中引用 ALPS？
+### 我在使用 ALPS 时遇到了问题，需要帮助。
 
-我们的软件发布出版物详见[本页面](../documentation/pubs/papers)。特定数值方法请参考[代码与方法参考文献](../documentation/pubs/refs)。引用要求在[引用说明页](../documentation/pubs/citations)有详细说明。
+如果您在网页或文档中找不到答案，有两种求助方式：在 Discord 上提问以获得即时帮助，或在 Issues 中提交问题。我们将尽力及时回复您。
 
-### 关于 ALPS 安装、文档或教程的问题应咨询何处？
+<div class="btn-grid">
+{{< cta-button text="Issues" link="https://github.com/ALPSim/ALPS/issues" icon="bug_report" >}}
+{{< cta-button text="Discord" link="https://discord.com/invite/JRNWnnva9g" icon="forum" >}}
+</div>
 
-我们创建了 Discord 频道供社区讨论。您可以在[Github 仓库讨论区](https://github.com/ALPSim/ALPS/discussions/categories/q-a)或[Discord 频道](https://discord.gg/JRNWnnva9g)提问。
+### 使用 ALPS 的条件是什么？
+
+ALPS 及其所有应用均以 [MIT 许可证](https://github.com/ALPSim/ALPS/blob/main/LICENSE)发布，这是目前最为宽松的开源许可证之一。您可以在几乎任何场景中自由使用、修改和分发 ALPS，包括将其集成到您自己的软件中或用于商业项目，限制极少。
+
+如果您使用 ALPS 并发表了相关科研成果，我们诚挚地希望您能引用我们的论文。请访问我们的[论文页面](../documentation/pubs/papers/)获取相应参考文献。
 
 ### 如何报告代码中的错误？
 
-欢迎在[Github 仓库的问题区](https://github.com/ALPSim/ALPS/issues)提交错误报告。我们的开发人员将立即调查潜在问题。
+如果您发现了错误，请在我们的 GitHub 仓库中提交 Issue。提交时，请遵循 GitHub 页面上提供的 Issue 模板，这有助于我们尽快复现并解决问题。您也可以直接在 Discord 上联系 ALPS 团队。我们将尽力及时跟进并回复。
+
+<div class="btn-grid">
+{{< cta-button text="Issues" link="https://github.com/ALPSim/ALPS/issues" icon="bug_report" >}}
+{{< cta-button text="Discord" link="https://discord.com/invite/JRNWnnva9g" icon="forum" >}}
+</div>
 
 ### 如何安装 ALPS？
 
-最简便的安装方式是在 Linux/Mac 系统或 Windows 的 Linux 子系统中使用[pyalps 二进制安装](../install/binary)。如需源码安装，请遵循[安装指南](../install/)中的 Linux/Mac 系统说明。
+详细安装说明请参阅我们的安装页面。我们支持[二进制](../install/binary/)、[Spack](../install/spack/) 和[源码](../install/source/)三种安装方式。
+
+<div class="btn-grid">
+{{< cta-button text="安装说明" link="../install/" icon="download" >}}
+</div>
 
 ### 如何为 ALPS 贡献代码？
 
-请[联系](../govern#alps-community-steering-committee)我们的领导团队成员获取详情。我们很乐意探讨您的项目方案。
-如果您是学生，希望在了解 ALPS 的过程中参与贡献，请参阅我们的[新人指南](../govern/onboard)。
+欢迎以多种方式为 ALPS 做出贡献——从承担现有代码的维护工作、贡献您自己的代码，到协助修复已知问题和错误，各种层次的参与都受到欢迎。第一步是联系我们的[社区指导委员会](../govern#alps-community-steering-committee)，他们将乐于探讨如何将您的工作融入项目。
+
+有意参与 ALPS 的本科生，欢迎阅读我们专为学生准备的[新人入门说明](../govern/onboard/)。
+
+<div class="btn-grid">
+{{< cta-button text="治理" link="../govern/" icon="account_balance" >}}
+{{< cta-button text="Issues" link="https://github.com/ALPSim/ALPS/issues" icon="bug_report" >}}
+</div>


### PR DESCRIPTION
## Summary

- Replaces the old citation and community Q&A entries with a single actionable "I have a problem and need help" entry (Discord + Issues buttons)
- Adds a new licensing FAQ explaining the MIT license and the citation request
- Expands the bug reporting FAQ to mention the GitHub issue template and Discord as an alternative channel
- Simplifies the installation FAQ with inline links to binary, Spack, and source options plus an Installation button
- Expands the contribution FAQ to cover all levels of involvement (maintenance, new code, bug fixes) and links to the student onboarding page; adds Governance + Issues buttons
- All changes applied consistently across English, Chinese (zh-cn), and Japanese (ja)

## Test plan

- [ ] `hugo server` — verify FAQ page renders correctly in all three languages
- [ ] Check that all buttons (Issues, Discord, Installation, Governance) link to the correct destinations
- [ ] Verify MIT license link resolves to the correct GitHub page
- [ ] Confirm inline links (binary, Spack, source, publications, onboarding) are not broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)