### PR TITLE
fix: mobile hamburger menu broken on homepage (iOS Safari/Chrome)

### DIFF
--- a/layouts/alps-home.html
+++ b/layouts/alps-home.html
@@ -1,5 +1,6 @@
 {{ define "main" }}
-  <div class="hx:mx-auto hextra-max-page-width">
+  <div class="hx:mx-auto hx:flex hextra-max-page-width">
+    {{ partial "sidebar.html" (dict "context" . "disableSidebar" true "displayPlaceholder" false) }}
     <article class="hx:w-full hx:break-words hx:flex hx:min-h-[calc(100vh-var(--navbar-height))] hx:min-w-0 hx:justify-center hx:pb-8 hx:pr-[calc(env(safe-area-inset-right)-1.5rem)]">
       <main id="content" class="hx:w-full hx:min-w-0 hx:max-w-6xl hx:px-6 hx:pt-4 hx:md:px-12">
         <div class="content">


### PR DESCRIPTION
## Summary

- Fixes #89 — the hamburger menu button in the top bar was completely non-functional on iPhone (iOS Safari and Chrome).
- Root cause: `alps-home.html` omitted `{{ partial "sidebar.html" ... }}`, so `.hextra-sidebar-container` was absent from the DOM on the homepage. `menu.js` calls `sidebarContainer.setAttribute(...)` immediately on `DOMContentLoaded` and throws a `TypeError: null`, aborting the handler before the hamburger click listener is ever registered.
- Fix: add the sidebar partial with `disableSidebar: true, displayPlaceholder: false`. This keeps the element hidden on desktop (`hx:md:hidden`) — no visual change for desktop users — while making the mobile overlay functional.

## Test plan

- [ ] On a real iPhone (or Chrome DevTools mobile emulation at ≤767 px), open the homepage and tap the hamburger icon — nav links should slide in.
- [ ] On desktop, verify the homepage layout is unchanged (no sidebar column appears).
- [ ] Navigate to any docs/content page and confirm the mobile menu still works there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ToAdF3RkbQXHRscg1CtiKV