### PR TITLE
Remove sample supercomputer batch script from Spack install docs

### DIFF
--- a/content/en/install/spack.md
+++ b/content/en/install/spack.md
@@ -62,30 +62,7 @@ spack load alps
 ### Spack Installation on Supercomputer Clusters
 If you need to install ALPS on a supercomputer cluster, we recommend submitting a batch job to install ALPS through a job node instead of running the above commands on a login node. Since the installation sometimes takes a long time, using login node to install ALPS could affect other users of the cluster. 
 
-We have successfully installed ALPS on the following supercomputer clusters: [NCSA Delta (Illinois)](https://docs.ncsa.illinois.edu/systems/delta/en/latest/index.html), [PSC Bridges (Pittsburgh)](https://www.psc.edu/resources/bridges-2/user-guide/), [Purdue Anvil](https://www.rcac.purdue.edu/anvil#docs), [SDSC Expanse (San Diego)](https://www.sdsc.edu/systems/expanse/user_guide.html), [TACC Stampede3 (Texas)](https://docs.tacc.utexas.edu/hpc/stampede3/). Please read their documentation about how to submit a batch job. Below is one sample batch script we used to install ALPS on the NCSA Delta supercomputer cluster.
-```
-#!/bin/bash
-#SBATCH --mem=16g
-#SBATCH --nodes=1
-#SBATCH --ntasks-per-node=1
-#SBATCH --cpus-per-task=1    # <- match to OMP_NUM_THREADS
-#SBATCH --partition=cpu      # <- or one of: gpuA100x4 gpuA40x4 gpuA100x8 gpuMI100x8
-#SBATCH --account=bdhb-delta-cpu    # <- match to a "Project" returned by the "accounts" command
-#SBATCH --job-name=installALPS
-#SBATCH --time=05:00:00      # hh:mm:ss for the job
-#SBATCH --constraint="scratch"
-#SBATCH -e slurm-%j.err
-#SBATCH -o slurm-%j.out
-### GPU options ###
-##SBATCH --gpus-per-node=2
-##SBATCH --gpu-bind=none     # <- or closest
-##SBATCH --mail-user=you@yourinstitution.edu
-##SBATCH --mail-type="BEGIN,END" See sbatch or srun man pages for more email options
-
-. spack/share/spack/setup-env.sh
-
-spack install alps
-```
+We have successfully installed ALPS on the following supercomputer clusters: [NCSA Delta (Illinois)](https://docs.ncsa.illinois.edu/systems/delta/en/latest/index.html), [PSC Bridges (Pittsburgh)](https://www.psc.edu/resources/bridges-2/user-guide/), [Purdue Anvil](https://www.rcac.purdue.edu/anvil#docs), [SDSC Expanse (San Diego)](https://www.sdsc.edu/systems/expanse/user_guide.html), [TACC Stampede3 (Texas)](https://docs.tacc.utexas.edu/hpc/stampede3/). Please read their documentation about how to submit a batch job. 
 
 ## Walkthrough Video
 

--- a/content/ja/install/spack.md
+++ b/content/ja/install/spack.md
@@ -62,30 +62,7 @@ spack load alps
 ### スーパーコンピュータクラスタでの Spack インストール
 スーパーコンピュータクラスタに ALPS をインストールする必要がある場合は、ログインノードで上記のコマンドを実行するのではなく、バッチジョブを投入してジョブノード上でインストールすることをお勧めします。インストールには長時間かかることがあるため、ログインノードでインストールを行うとクラスタの他のユーザに影響を与える可能性があります。
 
-以下のスーパーコンピュータクラスタでの ALPS のインストールに成功しています。[NCSA Delta (イリノイ州)](https://docs.ncsa.illinois.edu/systems/delta/en/latest/index.html)、[PSC Bridges (ピッツバーグ)](https://www.psc.edu/resources/bridges-2/user-guide/)、[Purdue Anvil](https://www.rcac.purdue.edu/anvil#docs)、[SDSC Expanse (サンディエゴ)](https://www.sdsc.edu/systems/expanse/user_guide.html)、[TACC Stampede3 (テキサス州)](https://docs.tacc.utexas.edu/hpc/stampede3/)。バッチジョブの投入方法については、それぞれのドキュメントを参照してください。以下は、NCSA Delta スーパーコンピュータクラスタで ALPS をインストールするために使用したバッチスクリプトのサンプルです。
-```
-#!/bin/bash
-#SBATCH --mem=16g
-#SBATCH --nodes=1
-#SBATCH --ntasks-per-node=1
-#SBATCH --cpus-per-task=1    # <- OMP_NUM_THREADS に合わせる
-#SBATCH --partition=cpu      # <- または gpuA100x4 gpuA40x4 gpuA100x8 gpuMI100x8 のいずれか
-#SBATCH --account=bdhb-delta-cpu    # <- "accounts" コマンドで返される "Project" に合わせる
-#SBATCH --job-name=installALPS
-#SBATCH --time=05:00:00      # ジョブの実行時間 (hh:mm:ss)
-#SBATCH --constraint="scratch"
-#SBATCH -e slurm-%j.err
-#SBATCH -o slurm-%j.out
-### GPU オプション ###
-##SBATCH --gpus-per-node=2
-##SBATCH --gpu-bind=none     # <- または closest
-##SBATCH --mail-user=you@yourinstitution.edu
-##SBATCH --mail-type="BEGIN,END" その他のメールオプションについては sbatch または srun のマニュアルページを参照
-
-. spack/share/spack/setup-env.sh
-
-spack install alps
-```
+以下のスーパーコンピュータクラスタでの ALPS のインストールに成功しています。[NCSA Delta (イリノイ州)](https://docs.ncsa.illinois.edu/systems/delta/en/latest/index.html)、[PSC Bridges (ピッツバーグ)](https://www.psc.edu/resources/bridges-2/user-guide/)、[Purdue Anvil](https://www.rcac.purdue.edu/anvil#docs)、[SDSC Expanse (サンディエゴ)](https://www.sdsc.edu/systems/expanse/user_guide.html)、[TACC Stampede3 (テキサス州)](https://docs.tacc.utexas.edu/hpc/stampede3/)。バッチジョブの投入方法については、それぞれのドキュメントを参照してください。
 
 ## インストール手順ビデオ
 

--- a/content/zh-cn/install/spack.md
+++ b/content/zh-cn/install/spack.md
@@ -62,30 +62,7 @@ spack load alps
 ### 在超算集群中通过 Spack 安装
 如果需要在超算集群中安装ALPS，我们建议通过提交批处理作业在计算节点上安装，而不是在登录节点上执行上述命令。由于安装过程有时耗时较长，在登录节点上安装可能会影响集群的其他用户。
 
-我们已在以下超算集群中成功安装过 ALPS：[NCSA Delta（伊利诺伊）](https://docs.ncsa.illinois.edu/systems/delta/en/latest/index.html)、[PSC Bridges（匹兹堡）](https://www.psc.edu/resources/bridges-2/user-guide/)、[Purdue Anvil](https://www.rcac.purdue.edu/anvil#docs)、[SDSC Expanse（圣地亚哥）](https://www.sdsc.edu/systems/expanse/user_guide.html)、[TACC Stampede3（德克萨斯）](https://docs.tacc.utexas.edu/hpc/stampede3/)。请阅读相应集群的文档以了解如何提交批处理作业。下面是我们用于在 NCSA Delta 超算集群中安装 ALPS 的一个示例批处理脚本。
-```
-#!/bin/bash
-#SBATCH --mem=16g
-#SBATCH --nodes=1
-#SBATCH --ntasks-per-node=1
-#SBATCH --cpus-per-task=1    # <- 与 OMP_NUM_THREADS 保持一致
-#SBATCH --partition=cpu      # <- 可选：gpuA100x4 gpuA40x4 gpuA100x8 gpuMI100x8
-#SBATCH --account=bdhb-delta-cpu    # <- 替换为 "accounts" 命令返回的某个 "Project"
-#SBATCH --job-name=installALPS
-#SBATCH --time=05:00:00      # 作业运行时间 hh:mm:ss
-#SBATCH --constraint="scratch"
-#SBATCH -e slurm-%j.err
-#SBATCH -o slurm-%j.out
-### GPU 选项 ###
-##SBATCH --gpus-per-node=2
-##SBATCH --gpu-bind=none     # <- 或 closest
-##SBATCH --mail-user=you@yourinstitution.edu
-##SBATCH --mail-type="BEGIN,END" 更多邮件选项请参阅 sbatch 或 srun 手册
-
-. spack/share/spack/setup-env.sh
-
-spack install alps
-```
+我们已在以下超算集群中成功安装过 ALPS：[NCSA Delta（伊利诺伊）](https://docs.ncsa.illinois.edu/systems/delta/en/latest/index.html)、[PSC Bridges（匹兹堡）](https://www.psc.edu/resources/bridges-2/user-guide/)、[Purdue Anvil](https://www.rcac.purdue.edu/anvil#docs)、[SDSC Expanse（圣地亚哥）](https://www.sdsc.edu/systems/expanse/user_guide.html)、[TACC Stampede3（德克萨斯）](https://docs.tacc.utexas.edu/hpc/stampede3/)。请阅读相应集群的文档以了解如何提交批处理作业。
 
 ## 安装视频指南
 


### PR DESCRIPTION
## Summary
- Removes the sample SBATCH batch script from the "Spack Installation on Supercomputer Clusters" section of the Spack install page, keeping the guidance to consult each cluster's own documentation for submitting batch jobs.
- Applied identically to the English, Simplified Chinese, and Japanese versions of `install/spack.md` to keep the three language trees in sync.

## Test plan
- [x] Verified all three language files (`content/en`, `content/zh-cn`, `content/ja`) have matching diffs
- [x] Preview locally with `hugo server` to confirm the install page renders correctly in all three languages