### PR TITLE
Expand DMFT-08 and rework DMFT-09 to match tutorial formatting guidelines

### DIFF
--- a/content/en/tutorials/dmft/dmft08.md
+++ b/content/en/tutorials/dmft/dmft08.md
@@ -7,11 +7,87 @@ toc: true
 
 ## Setting a particular lattice
 
+All of the previous tutorials dealt with the Bethe lattice, whose semicircular density of states (DOS) makes the self-consistency loop analytically simple ($\Omega$-loop, no k-space integral needed). Real materials, however, live on square, cubic, hexagonal, or more complicated lattices, whose density of states has van Hove singularities and hard band edges instead of a smooth semicircle. Because these features can shift where a Mott transition happens, or how sharp it looks, it is useful to know how to run single-site DMFT for a lattice other than the Bethe lattice. This tutorial shows how to do so, and you may reuse scripts from the previous tutorials (e.g. the Mott-transition scan of [DMFT-04 Mott](../dmft04)) with the lattice-specific parameters introduced below substituted in.
+
+### Model
+
+The lattice Hamiltonian is still the single-band Hubbard model
+
+$$
+\hat{H} = -\sum_{\langle i,j\rangle,\sigma} t_{ij}\left(\hat{c}^\dagger_{i\sigma}\hat{c}_{j\sigma} + \text{h.c.}\right) + U\sum_i \hat{n}_{i\uparrow}\hat{n}_{i\downarrow} - \mu\sum_{i,\sigma}\hat{n}_{i\sigma},
+$$
+
+now with $t_{ij}$ ranging over the bonds of whichever lattice is chosen, rather than the Bethe lattice's $z\to\infty$ tree. Within single-site DMFT, however, the lattice never enters the impurity problem directly: the self-consistency only ever needs the local, k-integrated non-interacting density of states $\rho_0(\epsilon)=\sum_{\mathbf{k}}\delta(\epsilon-\epsilon_{\mathbf{k}})$ (or, equivalently, the dispersion $\epsilon_{\mathbf{k}}$ if the Hilbert transform is done live in k-space). This is the DMFT analogue of how classical mean-field theory replaces the full lattice geometry by a single effective (coordination-number-dependent) field; see [Georges et al. (1996)](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13) for the general derivation of the self-consistency condition in terms of $\rho_0(\epsilon)$.
+
+### Parameters
+
+Parameters shared by both approaches below (values as used in `tutorial8a.py`/`tutorial8b.py`):
+
+| Parameter | Meaning | Value(s) used |
+| :-------- | :------ | :------------ |
+| `U` | on-site interaction | $3$ |
+| `BETA` | inverse temperature | $6$ |
+| `MU` | chemical potential | $0$ (half filling) |
+| `H`, `H_INIT` | quantization-axis field / seed field for the initial Weiss field | $0$ / $0.05$ |
+| `FLAVORS` | number of spin flavors | $2$ |
+| `SITES` | number of impurity sites | $1$ |
+| `ANTIFERROMAGNET` | enable the Néel self-consistency | $1$ |
+| `SYMMETRIZATION` | enforce a paramagnetic solution | $0$ |
+| `N`, `NMATSUBARA` | imaginary-time / Matsubara discretization of $G$ and $G_0$ | $500$ |
+| `OMEGA_LOOP` | run the self-consistency in Matsubara frequencies | $1$ |
+| `G0OMEGA_INPUT` | set to an empty string to force the initial Weiss field to be computed from the non-interacting Green's function | `""` |
+| `MAX_IT`, `CONVERGED` | maximum self-consistency iterations / convergence threshold | $10$, $0.005$ |
+| `SOLVER` | impurity solver | `"hybridization"` (CT-HYB) |
+| `SC_WRITE_DELTA`, `N_MEAS`, `N_ORDER` | write the hybridization function / MC updates between measurements / expansion-order histogram size | $1$, $5000$, $50$ |
+| `SWEEPS`, `THERMALIZATION`, `MAX_TIME` | Monte Carlo sweep budget, thermalization sweeps, wall-clock cutoff per iteration (seconds) | $10^4$, $500$, $60$ |
+
+### Lattice
+
+Two lattice-specific mechanisms are available; both feed a k-integrated density of states into the same self-consistency loop used in every earlier tutorial.
+
+**DOSFILE**: any lattice can be used, as long as you supply a table of its density of states. This tutorial ships pre-generated DOS tables (histograms) for four lattices, each with hopping normalized to $t=1$:
+
+- **square lattice** (`DOS_Square_GRID4000`, coordination $z=4$, second moment `EPSSQ_i=4`):
+  ```
+  o---o---o
+  |   |   |
+  o---o---o        o : lattice site, interaction U (on site)
+  |   |   |        --- , | : bond, nearest-neighbor hopping t
+  o---o---o
+  ```
+- **cubic lattice** (`DOS_Cubic_GRID360`, coordination $z=6$, second moment `EPSSQ_i=6`): the 3D generalization of the square lattice above, with an additional bond of hopping $t$ out of the page in each direction.
+- **hexagonal (honeycomb) lattice** (`DOS_Hexagonal_GRID4000`, coordination $z=3$, second moment `EPSSQ_i=3`):
+  ```
+        o---o       o---o
+       /     \     /     \
+      o       o---o       o     o : lattice site, interaction U (on site)
+       \     /     \     /      --- , / , \ : bond, nearest-neighbor hopping t
+        o---o       o---o
+  ```
+- **Bethe lattice** (`DOS_Bethe`, second moment `EPSSQ_i=1`, included for testing): the same lattice used in Tutorials 02–07, shown for reference:
+  ```
+          o       o
+           \     /
+        t   \   /   t
+             \ /
+          o---o---o          o : lattice site, interaction U (on site)
+             / \              --- : bond, hopping amplitude t
+            /   \
+           /     \
+          o       o
+  ```
+
+Each DOS table was produced by a small histogram script — [`DOS_Square.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Square.py) (`GRID=4000`), [`DOS_Cubic.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Cubic.py) (`GRID=360`), and [`DOS_Hexagonal.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Hexagonal.py) (`GRID=4000`) — each integrating the tight-binding dispersion over the Brillouin zone on a `GRID`$\times$`GRID` k-point mesh. You can generate a DOS table for any other lattice the same way, or use the [ALPS lattice library](../../../documentation/intro/latticehowtos) as a reference for lattice geometries and coordination numbers when building your own.
+
+**TWODBS**: for the square and hexagonal lattices specifically, ALPS can instead evaluate the Hilbert transform directly as a live k-space integral at every self-consistency step (discretized on an $L\times L$ k-point mesh), without needing a pre-tabulated DOS file at all.
+
+### Method choice
+
+`DOSFILE` and `TWODBS` trade off generality against convenience. `DOSFILE` works for *any* lattice, since only a one-time histogram of $\rho_0(\epsilon)$ is needed (generated once by a script like `DOS_Square.py` above) — but its accuracy is limited by the histogram's `GRID` resolution and bin count, and it must be regenerated if the hopping parameters change. `TWODBS` is exact up to the k-space discretization `L`, and needs no separate preprocessing step, but is currently implemented only for the square lattice (nearest-neighbor hopping `t` and next-nearest-neighbor hopping `tprime`) and the hexagonal lattice (nearest-neighbor hopping `t` only) — see [DMFT parameter reference](../../../documentation/methods/dmft) for the full parameter list. In both cases, the only lattice information that ever reaches the impurity solver is $\rho_0(\epsilon)$ (via `DOSFILE`) or $\epsilon_{\mathbf k}$ (via `TWODBS`) and its first two moments `EPS_i`, `EPSSQ_i` — confirming the point made in the Model section above: single-site DMFT only sees the lattice through its (integrated) non-interacting dispersion.
+
 ### Option DOSFILE
 
-All the previous tutorials dealt with the Bethe lattice, which has semicircular density of states. Now we show how to set the input parameters in order to specify density of states of a particular lattice. In order to run the simulation, you may take scripts from the previous tutorials and just replace the parameters list in order to do similar simulations. You may for instance look at the MIT as it was done in [DMFT-04 Mott](../dmft04).
-
-For a general lattice, you have to provide the density of states of your lattice. Apart from that, several other changes are necessary in order to run the simulation. A working python script [`tutorial8a.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/tutorial8a.py) setting an input file and running the simulation follows:
+For a general lattice, you have to provide the density of states of your lattice. Apart from that, several other changes are necessary in order to run the simulation. A working python script [`tutorial8a.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/tutorial8a.py) setting an input file, running the simulation, and plotting the result follows:
 
 ```
 import pyalps
@@ -61,9 +137,30 @@ for u in [3.]:
 for p in parms:
     input_file = pyalps.writeParameterFile('hybrid_DOS_beta_'+str(p['BETA'])+'_U_'+str(p['U']),p)
     res = pyalps.runDMFT(input_file)
+
+listobs=['0']  # we look only at flavor=0
+    
+data = pyalps.loadMeasurements(pyalps.getResultFiles(pattern='hybrid_DOS*h5'), respath='/simulation/results/G_tau', what=listobs, verbose=True)
+for d in pyalps.flatten(data):
+    d.x = d.x*d.props["BETA"]/float(d.props["N"])
+    d.props['label'] = r'$\beta=$'+str(d.props['BETA'])
+plt.figure()
+
+plt.xlabel(r'$\tau$')
+plt.ylabel(r'$G_{flavor=0}(\tau)$')
+plt.title('DMFT-08, DOS-based approach: Hubbard model on the square lattice')
+pyalps.plot.plot(data)
+plt.legend()
+plt.show()
 ```
 
-Lattice-specific parameters which appear in the input files are listed below:
+Internally, `pyalps.runDMFT` invokes the `dmft` application directly on the generated parameter file:
+
+```
+/path-to-alps-installation/bin/dmft hybrid_DOS_beta_6.0_U_3.0
+```
+
+The input file `hybrid_DOS_beta_6.0_U_3.0` produced by the script above has the lattice-specific parameters
 
 ```
 DOSFILE = DOS/DOS_Square_GRID4000; // specification of the file with density of states
@@ -74,16 +171,13 @@ EPSSQ_0 = 4;                      // the second moment of the bandstructure for 
 EPSSQ_1 = 4;                      // the second moment of the bandstructure for the flavor 1
 ```
 
+in addition to the physical/solver parameters listed in the Parameters table above. Note that the nearest-neighbor hopping is not an explicit parameter here — it is baked into the DOS table itself, and `DOS_Square.py` fixes it to $t=1$ by construction.
+
 Note 1: if you do not provide the bandstructure parameters (EPS_i, EPSSQ_i) in the input file, then they will be calculated using the given DOS (since revision 6146) as  $EPS_{flavor=i} = \int \mathrm{d}\epsilon\ DOS_{band=i/2}(\epsilon)\ \epsilon$, $EPSSQ_{flavor=i} = \int \mathrm{d}\epsilon\ DOS_{band=i/2}(\epsilon)\ \epsilon^2$.
 
 Note 2: the antiferromagnetic selfconsistency loop assumes Neel order. Therefore it is only applicable for bipartite lattices.
 
-Note 3: the density of states has to be provided by the user. In the tutorial we provide the DOS for
-
-- the square lattice DOS_Square_GRID4000 (generated by [`DOS_Square.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Square.py) for setting GRID=4000); the corresponding parameters are EPSSQ_i=4
-- the cubic lattice DOS_Cubic_GRID360 (generated by [`DOS_Cubic.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Cubic.py) for setting GRID=360); the corresponding parameters are EPSSQ_i=6
-- the hexagonal lattice DOS_Hexagonal_GRID4000 (generated by [`DOS_Hexagonal.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Hexagonal.py) for setting GRID=4000); the corresponding parameters are EPSSQ_i=3
-- the Bethe lattice DOS_Bethe (generated by `DOS_Bethe.py`); the corresponding parameters are EPSSQ_i=1; for testing
+Note 3: the density of states has to be provided by the user. In the tutorial we provide the DOS for the square, cubic, hexagonal, and Bethe lattices listed in the Lattice section above.
 
 Note 4: for a multiband simulation [$n_{\text{bands}}=FLAVORS/2$] with known DOS, the DOS-file has to consist of $2n_{\text{bands}}$ columns. The number of bins [=number of lines of the input file] for DOS has to be the same for all bands. The $i$-th line has the structure as follows
 
@@ -98,7 +192,7 @@ For the case of two-dimensional lattices, there is an implementation of the Hilb
 - square lattice [set TWODBS=square] with nearest-neighbor [corresponding parameter: t] and next-nearest-neighbor hoppings [corresponding parameter: tprime]; the second moment EPSSQ_i is $4(t^2 + tprime^2)$;
 - hexagonal lattice [set TWODBS=hexagonal] with nearest-neighbor hoppings [corresponding parameter: t]; the second moment EPSSQ_i is $3t^2$.
 
-A working python script [`tutorial8b.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/tutorial8b.py) to produce the input file and run the simulation is shown here:
+A working python script [`tutorial8b.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/tutorial8b.py) to produce the input file, run the simulation, and plot the result is shown here:
 
 ```
 import pyalps
@@ -151,9 +245,28 @@ for u in [3.]:
 for p in parms:
     input_file = pyalps.writeParameterFile('hybrid_TWODBS_beta_'+str(p['BETA'])+'_U_'+str(p['U']),p)
     res = pyalps.runDMFT(input_file)
+
+listobs=['0']  # we look only at flavor=0
+    
+data = pyalps.loadMeasurements(pyalps.getResultFiles(pattern='hybrid_TWODBS*h5'), respath='/simulation/results/G_tau', what=listobs, verbose=True)
+for d in pyalps.flatten(data):
+    d.x = d.x*d.props["BETA"]/float(d.props["N"])
+    d.props['label'] = r'$\beta=$'+str(d.props['BETA'])
+plt.figure()
+
+plt.xlabel(r'$\tau$')
+plt.ylabel(r'$G_{flavor=0}(\tau)$')
+plt.title('DMFT-08, TWODBS option: Hubbard model on the square lattice')
+pyalps.plot.plot(data)
+plt.legend()
+plt.show()
 ```
 
-The lattice-specific parameters are listed here:
+```
+/path-to-alps-installation/bin/dmft hybrid_TWODBS_beta_6.0_U_3.0
+```
+
+The lattice-specific parameters in the resulting input file `hybrid_TWODBS_beta_6.0_U_3.0` are:
 
 ```
 TWODBS = 1;     // the Hilbert transformation integral runs in k-space; sets square lattice
@@ -167,10 +280,19 @@ EPSSQ_0 = 4;                   // the second moment of the bandstructure for the
 EPSSQ_1 = 4;                   // the second moment of the bandstructure for the flavor 1
 ```
 
-### Final remarks
+Here `t=1` and `tprime=0` are explicit parameters (unlike the DOSFILE approach, where the hopping is fixed inside the pre-tabulated file), so `EPSSQ_i=4(t^2+tprime'^2)=4` follows directly from the formula given above.
 
-Question: what lattice information enters the DMFT calculation? Compare with classical mean-field.
+### Output data and plots
 
-Task: try to redo [DMFT-04 Mott](../dmft04) for a different lattice (than the Bethe lattice) and inspect the MIT. Are there any significant changes?
+Both `tutorial8a.py` (DOSFILE) and `tutorial8b.py` (TWODBS) end with the same kind of plot used throughout the earlier tutorials: the imaginary-time Green's function $G_{\text{flavor}=0}(\tau)$ at the end of the self-consistency loop, here for the square lattice at $U=3$, $\beta=6$. Because both scripts target the same lattice (square, $t=1$) and the same physical point, their converged $G(\tau)$ should agree with each other within statistical error — this is a useful cross-check that the DOSFILE histogram and the live TWODBS k-space integral describe the same physics.
 
-Recall the mean-field predictions for the Ising model (for different dimensions).
+Comparing this run to the Bethe-lattice results of [DMFT-02 Hybridization](../dmft02) and [DMFT-04 Mott](../dmft04) at the same $U$ and $\beta$, expect visible differences: the square lattice's DOS has a logarithmic van Hove singularity at the band center and hard edges at $\epsilon=\pm4t$, instead of the Bethe lattice's smooth semicircle, so the metal-insulator crossover happens at a different critical $U$ and the Green's function's short-time behavior differs even in the metallic phase.
+
+### Summary and outlook
+
+Single-site DMFT only ever needs the lattice's local density of states (or dispersion) — not its full real-space geometry — to close the self-consistency loop, whether that DOS comes from a pre-tabulated histogram (`DOSFILE`) or a live k-space Hilbert transform (`TWODBS`).
+
+1. What lattice information enters the DMFT calculation, precisely? Compare your answer to what enters a classical (Weiss) mean-field treatment of, say, the Ising model — in what sense is single-site DMFT itself a mean-field theory?
+2. Redo the Mott-transition scan of [DMFT-04 Mott](../dmft04) for the square lattice (`DOSFILE=DOS/DOS_Square_GRID4000` or `TWODBS=1`) instead of the Bethe lattice. Are there any significant changes to the critical $U$ or the shape of the crossover?
+3. Recall the mean-field predictions for the Ising model in different spatial dimensions (e.g. the mean-field critical temperature scales with the coordination number $z$). Does the coordination number of the lattices compared here ($z=3,4,6$ for hexagonal, square, cubic) leave a similar trace in the DMFT results?
+4. Run both `tutorial8a.py` (DOSFILE) and `tutorial8b.py` (TWODBS) at the same $U$, $\beta$, and compare the converged $G(\tau)$ curves directly. How does their agreement depend on the DOS histogram's `GRID` resolution versus the k-space discretization `L`?

--- a/content/en/tutorials/dmft/dmft09.md
+++ b/content/en/tutorials/dmft/dmft09.md
@@ -9,242 +9,113 @@ toc: true
 
 In this example we reproduce Fig. 11 in the DMFT review by [Georges et al.](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13). The series of six curves shows how the system, a Hubbard model on the Bethe lattice with interaction $U=3D/\sqrt{2}$ at half filling, enters an antiferromagnetic phase upon cooling.
 
-These examples can either be started by directly invoking a command or python script on the command line. Running one of the dmft parameter sets manually, e.g. by entering the directory `beta_14_U3_tsqrt2` in `tutorials/dmft-02-hybridization`, and running the dmft code `/opt/alps/bin/dmft hybrid.param`, leads to the same results.
+This tutorial merges [DMFT-02 Hybridization](../dmft02), [DMFT-03 Interaction](../dmft03), and [DMFT-07 Hirsch-Fye](../dmft07): the same physical point is solved with three algorithmically independent impurity solvers, and the results are compared directly on one plot.
 
-Note: the example merges the tutorials [DMFT-02 Hybridization](../dmft02), [DMFT-03 Interaction](../dmft03), and [DMFT-07 Hirsch-Fye](../dmft07).
+### Model
 
-### Hybridization Expansion CT-HYB
+As in Tutorials 02, 03, and 07, we solve the single-band Hubbard model
 
-We start by running a continuous-time quantum Monte Carlo code - the hybridization expansion algorithm CT-HYB. The CT-HYB simulation will run for about a minute per iteration. The parameter files for running this simulation can be found in the directory `tutorials/dmft-02-hybridization`.
+$$
+\hat{H} = -t\sum_{\langle i,j\rangle,\sigma} \left(\hat{c}^\dagger_{i\sigma}\hat{c}_{j\sigma} + \text{h.c.}\right) + U\sum_i \hat{n}_{i\uparrow}\hat{n}_{i\downarrow} - \mu\sum_{i,\sigma}\hat{n}_{i\sigma}
+$$
 
-The main parameters are:
+on the Bethe lattice at half filling ($\mu=0$), with $t=0.707106781186547=1/\sqrt{2}$ (half-bandwidth $D=2t=\sqrt{2}$) and $U=3$, so that $U=3D/\sqrt{2}$ as in [Georges et al. (1996)](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13). `ANTIFERROMAGNET=1` allows the Néel self-consistency, so cooling this point through a range of $\beta$ reproduces the metal-to-antiferromagnetic-insulator crossover of Fig. 11, independently of which impurity solver is used.
 
-```
-SEED = 0;                    // Monte Carlo Random Number Seed
-THERMALIZATION = 1000;       // Thermalization Sweeps
-SWEEPS = 100000000;          // Total Sweeps to be computed
-MAX_TIME = 60;               // Maximum time to run the simulation
-BETA = 12.;                  // Inverse temperature
-SITES = 1;                   // This is a single site DMFT simulation, so Sites is 1
-N = 1000;                    // auxiliary discretization of the imaginary-time Green's function
-NMATSUBARA = 1000;           // The number of Matsubara frequencies
-U = 3;                       // Interaction energy
-t = 0.707106781187;          // hopping parameter. For the Bethe lattice considered here $W=2D=4t$
-MU = 0;                      // Chemical potential
-H = 0;                       // Magnetic field
-SYMMETRIZATION = 0;          // We are not enforcing a paramagnetic self consistency condition
-SOLVER = Hybridization;      // The Hybridization solver
-```
+### Parameters
 
-To start a simulation with the command line, type:
+Full annotated parameter files for each solver are given in the corresponding tutorial; only the solver-differentiating settings are repeated here, at the common point $\beta=12$:
+
+| Parameter | Meaning | CT-HYB ([DMFT-02](../dmft02)) | CT-INT ([DMFT-03](../dmft03)) | Hirsch-Fye ([DMFT-07](../dmft07)) |
+| :-------- | :------ | :----------------------------- | :----------------------------- | :---------------------------------- |
+| `SOLVER` | impurity solver | `"hybridization"` | `"Interaction Expansion"` | `"hirschfye"` |
+| `N` | imaginary-time discretization | $250$ | $500$ | $16$ (small by construction, see [DMFT-07](../dmft07#method-choice)) |
+| solver-specific | additional parameters | `N_MEAS`, `N_ORDER`, `SC_WRITE_DELTA` | `ALPHA`, `HISTOGRAM_MEASUREMENT` | `TOLERANCE` |
+| shared | `U`, `t`, `BETA`, `MU`, `H`, `FLAVORS`, `ANTIFERROMAGNET`, `SYMMETRIZATION`, `NMATSUBARA`, `OMEGA_LOOP`, `SITES`, `SEED` | identical across all three solvers (see Model above) | | |
+
+### Running the simulations
+
+Each solver's short script writes `parm_beta_6.0` and `parm_beta_12.0` into its own tutorial directory and runs them:
 
 ```
-dmft hybrid.param
+cd tutorials/dmft-02-hybridization && python tutorial2.py    # CT-HYB
+cd tutorials/dmft-03-interaction   && python tutorial3.py    # CT-INT
+cd tutorials/dmft-07-hirschfye     && python tutorial7.py    # Hirsch-Fye
 ```
 
-The code will run for up to 10 self-consistency iterations. In the directory in which you run the program you will find Green's functions files G_tau_i as well the self energies (selfenergy_i) and Green's functions in frequency space G_omega_i in your output directory. G_tau in these examples has two entries: a spin-up and a spin-down column. The entry at $\beta$ is the negative density; where it is different outside of error bars the system is in an antiferromagnetic phase. You can run the following lines in the python shell in order to plot the Green's functions for different $\beta$ and compare your result to Fig. 11 of [Georges et al.](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13). In the Hirsch-Fye section below we will reproduce the same results with a discrete-time Quantum Monte Carlo code: the Hirsch Fye code. The parameters are the same, apart from the command for the solver.
-
-You can find the parameter files (called \*tsqrt2) in the directory `tutorials/dmft-02-hybridization` in the examples. Alternatively you can run the python script `tutorial2a.py`:
+or, directly on the command line, once the parameter files have been written:
 
 ```
-import pyalps
-import numpy as np
-import matplotlib.pyplot as plt
-import pyalps.pyplot
-
-#prepare the input parameters
-parms=[]
-for b in [6.,8.,10.,12.,14.,16.]:
-    parms.append(
-        {
-            'ANTIFERROMAGNET'     : 1,
-            'CONVERGED'           : 0.03,
-            'F'                   : 10,
-            'FLAVORS'             : 2,
-            'H'                   : 0,
-            'H_INIT'              : 0.2,
-            'MAX_IT'              : 10,
-            'MAX_TIME'            : 60,
-            'MU'                  : 0,
-            'N'                   : 1000,
-            'NMATSUBARA'          : 1000,
-            'N_FLIP'              : 0,
-            'N_MEAS'              : 10000,
-            'N_MOVE'              : 0,
-            'N_ORDER'             : 50,
-            'N_SHIFT'             : 0,
-            'OMEGA_LOOP'          : 1,
-            'OVERLAP'             : 0,
-            'SEED'                : 0,
-            'SITES'               : 1,
-            'SOLVER'              : 'Hybridization',
-            'SYMMETRIZATION'      : 0,
-            'TOLERANCE'           : 0.01,
-            'U'                   : 3,
-            't'                   : 0.707106781186547,
-            'SWEEPS'              : 100000000,
-            'THERMALIZATION'      : 1000,
-            'BETA'                : b,
-            'CHECKPOINT'          : 'solverdump_beta_'+str(b)+'.task1.out.h5',
-            'G0TAU_INPUT'         : 'G0_tau_input_beta_'+str(b)
-        }
-    )
-#write the input file and run the simulation
-for p in parms:
-    input_file = pyalps.writeParameterFile('parm_beta_'+str(p['BETA']),p)
-    res = pyalps.runDMFT(input_file)
+/path-to-alps-installation/bin/dmft tutorials/dmft-02-hybridization/parm_beta_12.0
+/path-to-alps-installation/bin/dmft tutorials/dmft-03-interaction/parm_beta_12.0
+/path-to-alps-installation/bin/dmft tutorials/dmft-07-hirschfye/parm_beta_12.0
 ```
 
-After running these simulations compare the output to the Hirsch-Fye results of the section Hirsch Fye or the DMFT review, or to the interaction expansion results of the section Interaction Expansion CT-INT. To rerun a simulation, you can specify a starting solution by defining G0OMEGA_INPUT, e.g. copy G0omga_output to G0_omega_input, specify G0OMEGA_INPUT = G0_omega_input in the parameter file and rerun the code. You can observe the transition to the antiferromagnetic phase by plotting the Green's functions using the script:
+See [DMFT-02](../dmft02#running-the-simulation), [DMFT-03](../dmft03#running-the-simulation), and [DMFT-07](../dmft07#running-the-simulation) for the full scripts and annotated parameter files.
+
+### Lattice
+
+All three solvers are run on the same Bethe lattice in the $z\to\infty$ limit used throughout this series, with hopping rescaled as $t=t^*/\sqrt{z}$ so that the semicircular density of states (half-bandwidth $D=2t$) is evaluated analytically in the self-consistency loop:
 
 ```
-flavors=parms[0]['FLAVORS']
-listobs=[]   
-for f in range(0,flavors):
-    listobs.append('Green_'+str(f))
-
-ll=pyalps.load.Hdf5Loader()
-data = ll.ReadMeasurementFromFile(pyalps.getResultFiles(pattern='parm_beta_*h5'), respath='/simulation/results/G_tau', measurements=listobs, verbose=True)
-for d in pyalps.flatten(data):
-    d.x = d.x*d.props["BETA"]/float(d.props["N"])
-    d.props['label'] = r'$\beta=$'+str(d.props['BETA'])
-plt.figure()
-plt.xlabel(r'$\tau$')
-plt.ylabel(r'$G(\tau)$')
-plt.title('Hubbard model on the Bethe lattice')
-pyalps.pyplot.plot(data)
-plt.legend()
-plt.show()
+        o       o
+         \     /
+      t   \   /   t
+           \ /
+        o---o---o          o : lattice site, interaction U (on site)
+           / \              --- : bond, hopping amplitude t
+          /   \
+         /     \
+        o       o
 ```
 
-You will notice that the results are relatively noisy. The reason for that is that the expansion order at such high temperatures is very small, which renders the measurement procedure inefficient. You can improve statistics by increasing the total run time (MAX_TIME) or by running it on more than one CPU. For running it with MPI, try `mpirun -np procs dmft parameter_file` or consult the man page of your mpi installation.
+See [DMFT-08 Lattices](../dmft08) for running the same comparison on a different lattice.
 
-If you want to check the convergence of your DMFT self-consistency, you can plot the Green's functions of different iterations using `tutorial2b.py`:
+### Method choice
 
-```
-ll=pyalps.load.Hdf5Loader()
-for p in parms:
-    data = ll.ReadDMFTIterations(pyalps.getResultFiles(pattern='parm_beta_'+str(p['BETA'])+'.h5'), measurements=listobs, verbose=True)
-    grouped = pyalps.groupSets(pyalps.flatten(data), ['iteration'])
-    nd=[]
-    for group in grouped:
-        r = pyalps.DataSet()
-        r.y = np.array(group[0].y)
-        r.x = np.array([e*group[0].props['BETA']/float(group[0].props['N']) for e in group[0].x])
-        r.props = group[0].props
-        r.props['label'] = r.props['iteration']
-        nd.append( r )
-    plt.figure()
-    plt.xlabel(r'$\tau$')
-    plt.ylabel(r'$G(\tau)$')
-    plt.title(r'\beta = %.4s' %nd[0].props['BETA'])
-    pyalps.pyplot.plot(nd)
-    plt.legend()
-    plt.show()
-```
+CT-HYB, CT-INT, and Hirsch-Fye are built on unrelated approximations: CT-HYB expands in the hybridization and is most efficient at strong coupling; CT-INT expands in the interaction and is most efficient at weak-to-moderate coupling; Hirsch-Fye discretizes imaginary time into $N$ slices and carries a systematic $(\Delta\tau)^2$ bias that must be extrapolated away (see [DMFT-02](../dmft02), and the Method choice sections of [DMFT-03](../dmft03#method-choice) and [DMFT-07](../dmft07#method-choice), for the details of each). At $U=3D/\sqrt{2}$, none of these three algorithms is working in a regime that is obviously favorable or unfavorable for it, which makes this point a good place to cross-check them against each other: since the three solvers share no common systematic bias, any feature that appears in all three converged results — in particular, the antiferromagnetic splitting of $G(\tau)$ on cooling — must be a property of the physical model and the DMFT self-consistency, not an artifact of one particular Monte Carlo algorithm.
 
-It is usually best to observe convergence in the self energy, which is much more sensitive. Note that longer simulations are required to obtain smoother Green's fuctions and self energies.
+### Output data and plots
 
-### Interaction Expansion CT-INT
-
-It is instructive to run the same calculations as in the section Hybridization Expansion CT-HYB with a CT-INT code. This code performs an expansion in the interaction (instead of the hybridization). The corresponding parameter files are very similar, you can find them in the directory `tutorials/dmft-03-interaction`. If you prefer to run the simulations in python you can use `tutorial3a.py` and `tutorial3b.py` files.
-
-### Hirsch Fye
-
-We compare the continous time results by running a discrete time Monte Carlo code: the [Hirsch Fye code](https://link.aps.org/doi/10.1103/PhysRevLett.56.2521). The Hirsch Fye algorithm is described in [here](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13), and this review also provides an open source implementation for the codes. While many improvements have been developed (see e.g. Alvarez (2008) or [Nukala09](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.80.195111)), the algorithm has been replaced by [continuous-time algorithms](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.76.235123).
-
-The Hirsch Fye simulation will run for about a minute per iteration. The parameter files for running this simulation can be found in [this tutorial](../dmft07).
-
-The main parameters are:
-
-```
-SEED = 0;                    // Monte Carlo Random Number Seed
-THERMALIZATION = 10000;      // Thermalization Sweeps
-SWEEPS = 1000000;            // Total Sweeps to be computed
-MAX_TIME = 60;               // Maximum time to run the simulation
-BETA = 12.;                  // Inverse temperature
-SITES = 1;                   // This is a single site DMFT simulation, so Sites is 1
-N = 16;                      // Number of time slices (you will see that this parameter is rather small)
-NMATSUBARA = 500;            // The number of Matsubara frequencies
-U = 3;                       // Interaction energy
-t = 0.707106781187;          // hopping parameter. For the Bethe lattice considered here $W=2D=4t$
-MU = 0;                      // Chemical potential
-H = 0;                       // Magnetic field
-SYMMETRIZATION = 0;          // We are not enforcing a paramagnetic self consistency condition
-SOLVER = /opt/alps/bin/hirschfye;  // The path to the external Hirsch Fye solver
-```
-
-To start a simulation type:
-
-```
-dmft hirschfye.param
-```
-
-or run the python script `tutorial7a.py`:
+Rather than plotting each solver's result separately (as in Tutorials 02, 03, and 07), the point of this tutorial is to overlay all three on the same figure:
 
 ```
 import pyalps
 import numpy as np
 import matplotlib.pyplot as plt
-import pyalps.pyplot
+import pyalps.plot
 
-#prepare the input parameters 
-parms=[]
-for b in [6.,8.,10.,12.,14.,16.]: 
-    parms.append(
-        { 
-            'ANTIFERROMAGNET'     : 1,
-            'CONVERGED'           : 0.03,
-            'FLAVORS'             : 2,
-            'H'                   : 0,
-            'MAX_IT'              : 10,
-            'MAX_TIME'            : 60,
-            'MU'                  : 0,
-            'N'                   : 16,
-            'NMATSUBARA'          : 500, 
-            'OMEGA_LOOP'          : 1,
-            'SEED'                : 0, 
-            'SITES'               : 1,
-            'SOLVER'              : '/opt/alps/bin/hirschfye',
-            'SYMMETRIZATION'      : 0,
-            'TOLERANCE'           : 0.01,
-            'U'                   : 3,
-            't'                   : 0.707106781186547,
-            'SWEEPS'              : 1000000,
-            'THERMALIZATION'      : 10000,
-            'BETA'                : b,
-            'G0OMEGA_INPUT'       : 'G0_omega_input_beta_'+str(b),
-            'BASENAME'            : 'hirschfye.param'
-        }
-    )
+listobs = ['0']  # flavor 0
 
-#write the input file and run the simulation
-for p in parms:
-    input_file = pyalps.writeParameterFile('parm_beta_'+str(p['BETA']),p)
-    res = pyalps.runDMFT(input_file)
-```
+files = {
+    'CT-HYB'     : 'tutorials/dmft-02-hybridization/parm_beta_12.0.h5',
+    'CT-INT'     : 'tutorials/dmft-03-interaction/parm_beta_12.0.h5',
+    'Hirsch-Fye' : 'tutorials/dmft-07-hirschfye/parm_beta_12.0.h5',
+}
 
-The code will run for up to 10 self-consistency iterations. In the directory in which you run the program you will find Green's functions files G_tau_i as well the self energies (selfenergy_i) and Green's functions in frequency space G_omega_i in your output directory. G_tau in these examples has two entries: a spin-up and a spin-down column. The entry at $\beta$ is the negative density; where it is different outside of error bars the system is in an antiferromagnetic phase. You can run the following lines in the python shell in order to plot the Green's functions for different $\beta$ and compare your result to Fig. 11 of [Georges et al.](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13).
+alldata = []
+for solver, fname in files.items():
+    data = pyalps.loadMeasurements([fname], respath='/simulation/results/G_tau', what=listobs, verbose=False)
+    for d in pyalps.flatten(data):
+        d.x = d.x*d.props["BETA"]/float(d.props["N"])
+        d.props['label'] = solver
+        alldata.append(d)
 
-```
-flavors=parms[0]['FLAVORS']
-listobs=[]   
-for f in range(0,flavors):
-    listobs.append('Green_'+str(f))
-
-ll=pyalps.load.Hdf5Loader()
-data = ll.ReadMeasurementFromFile(pyalps.getResultFiles(pattern='parm_beta_*h5'), respath='/simulation/results/G_tau', measurements=listobs, verbose=True)
-for d in pyalps.flatten(data):
-    d.x = d.x*d.props["BETA"]/float(d.props["N"])
-    d.props['label'] = r'$\beta=$'+str(d.props['BETA'])
 plt.figure()
 plt.xlabel(r'$\tau$')
-plt.ylabel(r'$G(\tau)$')
-plt.title('Hubbard model on the Bethe lattice')
-pyalps.pyplot.plot(data)
+plt.ylabel(r'$G_{flavor=0}(\tau)$')
+plt.title('DMFT-09: Neel transition at BETA=12, solver comparison')
+pyalps.plot.plot(alldata)
 plt.legend()
 plt.show()
 ```
 
-As a discrete time method, HF suffers from $\Delta\tau$ discretization errors. Pick a set of parameters and run it for successively larger $N$! Also: you're running the DMFT simulation using an (almost) converged input bath function. By deleting the file G0_omega_input you can restart the calculation from the free solution and observe convergence.
+Because this compares three independent stochastic simulations, the actual numbers depend on `SEED`, `MAX_TIME`, and machine speed for each run, but the three curves should agree within their respective error bars — Hirsch-Fye's `N=16` discretization bias is visible relative to CT-HYB and CT-INT unless you extrapolate it as suggested in [DMFT-07](../dmft07#summary-and-outlook). You can rerun a solver from a partially converged solution rather than from scratch: copy the desired `G0omega_output` to a new filename and specify it via `G0OMEGA_INPUT` in the parameter file (or the corresponding python dictionary) before rerunning.
 
+### Summary and outlook
+
+Solving the same Néel transition with CT-HYB, CT-INT, and Hirsch-Fye and finding agreement between all three is a direct check that DMFT-02, DMFT-03, and DMFT-07 are converging to the same physics rather than to solver-specific artifacts.
+
+1. Extend the combined plot above to all six values of $\beta$ (using `tutorial2_long.py`, `tutorial3_long.py`, and `tutorial7_long.py`) and reproduce the full Fig. 11 comparison, with all three solvers overlaid at each temperature.
+2. At fixed wall-clock budget, which of the three solvers gives the smallest error bars at $\beta=12$? Does the ranking change at $\beta=6$, where the system is closer to the paramagnetic side?
+3. Extrapolate the Hirsch-Fye result to $\Delta\tau\to0$ (see [DMFT-07](../dmft07#summary-and-outlook)) before including it in the combined plot. Does the extrapolated curve move noticeably closer to CT-HYB and CT-INT?
+4. [DMFT-06](../dmft06) performs a similar cross-solver comparison, but in the paramagnetic metallic phase and against the numerically exact Exact Diagonalization/Hirsch-Fye benchmark of Fig. 15 in [Georges et al. (1996)](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13). Compare the two comparisons: is solver agreement easier to achieve in the paramagnetic metal of Tutorial 06 or in the antiferromagnetic phase studied here?

--- a/content/ja/tutorials/dmft/dmft08.md
+++ b/content/ja/tutorials/dmft/dmft08.md
@@ -7,11 +7,87 @@ toc: true
 
 ## Setting a particular lattice
 
+これまでのすべてのチュートリアルでは、半円形の状態密度（DOS）を持つベーテ格子を扱ってきました。これにより自己無撞着ループは解析的に単純になります（$\Omega$ループで、k空間積分を必要としません）。しかし現実の物質は正方格子、立方格子、六角格子、あるいはさらに複雑な格子の上に存在し、それらの状態密度は滑らかな半円ではなく、ファン・ホーブ特異点や硬いバンド端を持ちます。これらの特徴はモット転移が起こる場所やその鋭さを変化させ得るため、ベーテ格子以外の格子に対して単サイト DMFT を実行する方法を知っておくことは有用です。このチュートリアルではその方法を示します。以下で導入する格子固有のパラメータを差し替えれば、これまでのチュートリアルのスクリプト（例えば [DMFT-04 Mott](../dmft04) のモット転移スキャン）をそのまま再利用できます。
+
+### 模型
+
+格子ハミルトニアンは、これまでと同じ単バンド Hubbard 模型
+
+$$
+\hat{H} = -\sum_{\langle i,j\rangle,\sigma} t_{ij}\left(\hat{c}^\dagger_{i\sigma}\hat{c}_{j\sigma} + \text{h.c.}\right) + U\sum_i \hat{n}_{i\uparrow}\hat{n}_{i\downarrow} - \mu\sum_{i,\sigma}\hat{n}_{i\sigma}
+$$
+
+ですが、今回は $t_{ij}$ が選んだ格子のボンド上を走り、ベーテ格子の $z\to\infty$ の木構造ではありません。しかし単サイト DMFT では、格子は不純物問題に直接は入ってきません。自己無撞着計算が必要とするのは、局所的な、k について積分された非相互作用状態密度 $\rho_0(\epsilon)=\sum_{\mathbf{k}}\delta(\epsilon-\epsilon_{\mathbf{k}})$（あるいは、Hilbert 変換を k 空間で直接行う場合には分散関係 $\epsilon_{\mathbf{k}}$ そのもの）だけです。これは、古典的な平均場理論が格子全体の幾何学的構造を単一の有効な（配位数に依存する）場で置き換えるのと同じ発想です。局所状態密度 $\rho_0(\epsilon)$ を用いた自己無撞着条件の一般的な導出については [Georges et al. (1996)](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13) を参照してください。
+
+### パラメータ
+
+以下の2つの方法に共通するパラメータです（`tutorial8a.py`／`tutorial8b.py` で用いられている値）。
+
+| パラメータ | 意味 | 使用する値 |
+| :-------- | :------ | :------------ |
+| `U` | オンサイト相互作用 | $3$ |
+| `BETA` | 逆温度 | $6$ |
+| `MU` | 化学ポテンシャル | $0$（半充填） |
+| `H`, `H_INIT` | 量子化軸方向の磁場／初期外斯場の種となる磁場 | $0$ / $0.05$ |
+| `FLAVORS` | スピンフレーバー数 | $2$ |
+| `SITES` | 不純物サイト数 | $1$ |
+| `ANTIFERROMAGNET` | ネール自己無撞着を有効化 | $1$ |
+| `SYMMETRIZATION` | 常磁性解を強制するか | $0$ |
+| `N`, `NMATSUBARA` | $G$ と $G_0$ の虚時間／松原周波数離散化数 | $500$ |
+| `OMEGA_LOOP` | 自己無撞着計算を松原周波数で行う | $1$ |
+| `G0OMEGA_INPUT` | 空文字列を指定し、初期外斯場を非相互作用グリーン関数から強制的に計算させる | `""` |
+| `MAX_IT`, `CONVERGED` | 自己無撞着反復の最大回数／収束判定基準 | $10$、$0.005$ |
+| `SOLVER` | 不純物ソルバー | `"hybridization"`（CT-HYB） |
+| `SC_WRITE_DELTA`, `N_MEAS`, `N_ORDER` | ハイブリダイゼーション関数の出力／測定間のモンテカルロ更新回数／展開次数のヒストグラムサイズ | $1$、$5000$、$50$ |
+| `SWEEPS`, `THERMALIZATION`, `MAX_TIME` | モンテカルロスイープ数の上限／熱化スイープ数／1反復あたりの実時間上限（秒） | $10^4$、$500$、$60$ |
+
+### 格子
+
+格子固有の仕組みは2種類あり、どちらも同じ自己無撞着ループに、k について積分された状態密度を与えます。
+
+**DOSFILE**：状態密度の表を用意しさえすれば、どんな格子でも使用できます。このチュートリアルには、ホッピングを $t=1$ に規格化した4種類の格子について、あらかじめ生成された DOS 表（ヒストグラム）が同梱されています。
+
+- **正方格子**（`DOS_Square_GRID4000`、配位数 $z=4$、二次モーメント `EPSSQ_i=4`）：
+  ```
+  o---o---o
+  |   |   |
+  o---o---o        o : lattice site, interaction U (on site)
+  |   |   |        --- , | : bond, nearest-neighbor hopping t
+  o---o---o
+  ```
+- **立方格子**（`DOS_Cubic_GRID360`、配位数 $z=6$、二次モーメント `EPSSQ_i=6`）：上の正方格子を3次元に拡張したもので、各方向に紙面から飛び出す方向のホッピング $t$ のボンドが1本追加されます。
+- **六角（ハニカム）格子**（`DOS_Hexagonal_GRID4000`、配位数 $z=3$、二次モーメント `EPSSQ_i=3`）：
+  ```
+        o---o       o---o
+       /     \     /     \
+      o       o---o       o     o : lattice site, interaction U (on site)
+       \     /     \     /      --- , / , \ : bond, nearest-neighbor hopping t
+        o---o       o---o
+  ```
+- **ベーテ格子**（`DOS_Bethe`、二次モーメント `EPSSQ_i=1`、テスト用に同梱）：チュートリアル02〜07で用いたのと同じ格子で、参考として示します。
+  ```
+          o       o
+           \     /
+        t   \   /   t
+             \ /
+          o---o---o          o : lattice site, interaction U (on site)
+             / \              --- : bond, hopping amplitude t
+            /   \
+           /     \
+          o       o
+  ```
+
+各 DOS 表は小さなヒストグラム生成スクリプト──[`DOS_Square.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Square.py)（`GRID=4000`）、[`DOS_Cubic.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Cubic.py)（`GRID=360`）、[`DOS_Hexagonal.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Hexagonal.py)（`GRID=4000`）──によって、`GRID`$\times$`GRID` の k 点メッシュ上でタイトバインディング分散をブリルアンゾーン全体にわたって積分することで生成されています。他の格子についても同様の方法で自分で DOS 表を生成できますし、格子の幾何学的構造や配位数を調べる際の参考として [ALPS 格子ライブラリ](../../../documentation/intro/latticehowtos) を利用することもできます。
+
+**TWODBS**：正方格子と六角格子については、事前に DOS 表を用意しなくても、自己無撞着計算の各ステップで Hilbert 変換を（$L\times L$ の k 点メッシュ上で離散化した）ライブな k 空間積分として直接評価することができます。
+
+### 手法の選択
+
+`DOSFILE` と `TWODBS` は、汎用性と利便性のトレードオフの関係にあります。`DOSFILE` は $\rho_0(\epsilon)$ の（上記の `DOS_Square.py` のようなスクリプトによる）一度限りのヒストグラム作成だけで済むため、*あらゆる*格子に使えますが、その精度はヒストグラムの `GRID` 解像度とビン数に制限され、ホッピングパラメータを変更した場合は再生成が必要です。`TWODBS` は k 空間離散化 `L` の範囲内で厳密であり、別途の前処理ステップも不要ですが、現在実装されているのは正方格子（最近接ホッピング `t` と次近接ホッピング `tprime`）と六角格子（最近接ホッピング `t` のみ）に限られます──詳細は [DMFT パラメータリファレンス](../../../documentation/methods/dmft) を参照してください。いずれの場合も、不純物ソルバーに到達する格子情報は $\rho_0(\epsilon)$（`DOSFILE` 経由）あるいは $\epsilon_{\mathbf k}$（`TWODBS` 経由）とその一次・二次モーメント `EPS_i`、`EPSSQ_i` だけです。これは、上の「模型」の節で述べた点、すなわち単サイト DMFT は格子を（積分された）非相互作用分散を通してしか見ていない、ということを裏付けています。
+
 ### Option DOSFILE
 
-これまでのすべてのチュートリアルでは、半円形の状態密度を持つベーテ格子を扱ってきました。ここでは、特定の格子の状態密度を指定するために入力パラメータをどのように設定するかを示します。シミュレーションを実行するには、これまでのチュートリアルのスクリプトをそのまま使い、パラメータリストを置き換えるだけで同様のシミュレーションを行うことができます。例えば、[DMFT-04 Mott](../dmft04) で行ったように MIT を調べることができます。
-
-一般の格子の場合、その格子の状態密度を与える必要があります。それに加えて、シミュレーションを実行するにはいくつかの変更が必要です。入力ファイルを設定してシミュレーションを実行する、実際に動作する python スクリプト [`tutorial8a.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/tutorial8a.py) を以下に示します。
+一般の格子の場合、その格子の状態密度を与える必要があります。それに加えて、シミュレーションを実行するにはいくつかの変更が必要です。入力ファイルを設定し、シミュレーションを実行し、結果をプロットする、実際に動作する python スクリプト [`tutorial8a.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/tutorial8a.py) を以下に示します。
 
 ```
 import pyalps
@@ -61,9 +137,30 @@ for u in [3.]:
 for p in parms:
     input_file = pyalps.writeParameterFile('hybrid_DOS_beta_'+str(p['BETA'])+'_U_'+str(p['U']),p)
     res = pyalps.runDMFT(input_file)
+
+listobs=['0']  # we look only at flavor=0
+    
+data = pyalps.loadMeasurements(pyalps.getResultFiles(pattern='hybrid_DOS*h5'), respath='/simulation/results/G_tau', what=listobs, verbose=True)
+for d in pyalps.flatten(data):
+    d.x = d.x*d.props["BETA"]/float(d.props["N"])
+    d.props['label'] = r'$\beta=$'+str(d.props['BETA'])
+plt.figure()
+
+plt.xlabel(r'$\tau$')
+plt.ylabel(r'$G_{flavor=0}(\tau)$')
+plt.title('DMFT-08, DOS-based approach: Hubbard model on the square lattice')
+pyalps.plot.plot(data)
+plt.legend()
+plt.show()
 ```
 
-入力ファイルに現れる格子に固有のパラメータを以下に示します。
+内部的には、`pyalps.runDMFT` は生成されたパラメータファイルに対して `dmft` アプリケーションを直接呼び出します。
+
+```
+/path-to-alps-installation/bin/dmft hybrid_DOS_beta_6.0_U_3.0
+```
+
+上記のスクリプトによって生成される入力ファイル `hybrid_DOS_beta_6.0_U_3.0` には、格子固有のパラメータとして
 
 ```
 DOSFILE = DOS/DOS_Square_GRID4000; // specification of the file with density of states
@@ -74,16 +171,13 @@ EPSSQ_0 = 4;                      // the second moment of the bandstructure for 
 EPSSQ_1 = 4;                      // the second moment of the bandstructure for the flavor 1
 ```
 
+が含まれており、これに加えて上のパラメータ表にある物理／ソルバーパラメータも入っています。ここでは最近接ホッピングが明示的なパラメータとして現れていないことに注意してください──それは DOS 表そのものに組み込まれており、`DOS_Square.py` はホッピングを $t=1$ に固定して構築しています。
+
 注1：入力ファイル内でバンド構造パラメータ（EPS_i、EPSSQ_i）を指定しない場合、これらは与えられた DOS から（リビジョン6146以降）$EPS_{flavor=i} = \int \mathrm{d}\epsilon\ DOS_{band=i/2}(\epsilon)\ \epsilon$、$EPSSQ_{flavor=i} = \int \mathrm{d}\epsilon\ DOS_{band=i/2}(\epsilon)\ \epsilon^2$ として計算されます。
 
 注2：反強磁性の自己無撞着ループはネール秩序を仮定しているため、二部格子（bipartite lattice）にのみ適用可能です。
 
-注3：状態密度はユーザーが用意する必要があります。このチュートリアルでは以下の状態密度を提供しています。
-
-- 正方格子 DOS_Square_GRID4000（GRID=4000 の設定で [`DOS_Square.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Square.py) により生成）。対応するパラメータは EPSSQ_i=4
-- 立方格子 DOS_Cubic_GRID360（GRID=360 の設定で [`DOS_Cubic.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Cubic.py) により生成）。対応するパラメータは EPSSQ_i=6
-- 六角格子 DOS_Hexagonal_GRID4000（GRID=4000 の設定で [`DOS_Hexagonal.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Hexagonal.py) により生成）。対応するパラメータは EPSSQ_i=3
-- ベーテ格子 DOS_Bethe（`DOS_Bethe.py` により生成）。対応するパラメータは EPSSQ_i=1（テスト用）
+注3：状態密度はユーザーが用意する必要があります。このチュートリアルでは、上の「格子」の節に挙げた正方格子・立方格子・六角格子・ベーテ格子の状態密度を提供しています。
 
 注4：既知の DOS を用いたマルチバンドシミュレーション [$n_{\text{bands}}=FLAVORS/2$] では、DOS ファイルは $2n_{\text{bands}}$ 列から構成されている必要があります。DOS のビン数（＝入力ファイルの行数）はすべてのバンドで同じでなければなりません。$i$ 行目の構造は以下の通りです。
 
@@ -98,7 +192,7 @@ $$
 - 正方格子 [TWODBS=square と設定]。最近接ホッピング [対応するパラメータ：t] と次近接ホッピング [対応するパラメータ：tprime] を持ち、二次モーメント EPSSQ_i は $4(t^2 + tprime^2)$ です。
 - 六角格子 [TWODBS=hexagonal と設定]。最近接ホッピングのみを持ち [対応するパラメータ：t]、二次モーメント EPSSQ_i は $3t^2$ です。
 
-入力ファイルを生成してシミュレーションを実行する、実際に動作する python スクリプト [`tutorial8b.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/tutorial8b.py) を以下に示します。
+入力ファイルを生成し、シミュレーションを実行し、結果をプロットする、実際に動作する python スクリプト [`tutorial8b.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/tutorial8b.py) を以下に示します。
 
 ```
 import pyalps
@@ -151,9 +245,28 @@ for u in [3.]:
 for p in parms:
     input_file = pyalps.writeParameterFile('hybrid_TWODBS_beta_'+str(p['BETA'])+'_U_'+str(p['U']),p)
     res = pyalps.runDMFT(input_file)
+
+listobs=['0']  # we look only at flavor=0
+    
+data = pyalps.loadMeasurements(pyalps.getResultFiles(pattern='hybrid_TWODBS*h5'), respath='/simulation/results/G_tau', what=listobs, verbose=True)
+for d in pyalps.flatten(data):
+    d.x = d.x*d.props["BETA"]/float(d.props["N"])
+    d.props['label'] = r'$\beta=$'+str(d.props['BETA'])
+plt.figure()
+
+plt.xlabel(r'$\tau$')
+plt.ylabel(r'$G_{flavor=0}(\tau)$')
+plt.title('DMFT-08, TWODBS option: Hubbard model on the square lattice')
+pyalps.plot.plot(data)
+plt.legend()
+plt.show()
 ```
 
-格子に固有のパラメータを以下に示します。
+```
+/path-to-alps-installation/bin/dmft hybrid_TWODBS_beta_6.0_U_3.0
+```
+
+生成される入力ファイル `hybrid_TWODBS_beta_6.0_U_3.0` の格子固有のパラメータは以下の通りです。
 
 ```
 TWODBS = 1;     // the Hilbert transformation integral runs in k-space; sets square lattice
@@ -167,10 +280,19 @@ EPSSQ_0 = 4;                   // the second moment of the bandstructure for the
 EPSSQ_1 = 4;                   // the second moment of the bandstructure for the flavor 1
 ```
 
-### Final remarks
+ここでは `t=1`、`tprime=0` が明示的なパラメータとして与えられているため（DOSFILE 方式ではホッピングは事前生成された DOS 表の中に固定されていました）、`EPSSQ_i=4(t^2+tprime^2)=4` が上記の公式から直接得られます。
 
-問題：DMFT の計算にはどのような格子の情報が入ってくるでしょうか。古典的な平均場理論と比較してください。
+### 出力データとプロット
 
-課題：（ベーテ格子以外の）別の格子について [DMFT-04 Mott](../dmft04) をやり直し、MIT を調べてみてください。何か顕著な変化はあるでしょうか。
+`tutorial8a.py`（DOSFILE）と `tutorial8b.py`（TWODBS）はどちらも、これまでのチュートリアルと同じ種類のプロット──自己無撞着ループの最後における虚時間グリーン関数 $G_{\text{flavor}=0}(\tau)$──で終わります。ここでは $U=3$、$\beta=6$ における正方格子の結果です。両スクリプトとも同じ格子（正方格子、$t=1$）と同じ物理的な点を対象としているため、収束した $G(\tau)$ は統計誤差の範囲内で互いに一致するはずです。これは、DOSFILE のヒストグラムと TWODBS のライブな k 空間積分が同じ物理を記述していることを確認する良いチェックになります。
 
-Ising 模型に対する（さまざまな次元での）平均場理論の予言を思い出してください。
+この結果を、同じ $U$、$\beta$ における [DMFT-02 Hybridization](../dmft02) や [DMFT-04 Mott](../dmft04) のベーテ格子の結果と比較すると、目に見える違いが予想されます。正方格子の状態密度はバンド中心に対数的なファン・ホーブ特異点を持ち、$\epsilon=\pm4t$ に硬いバンド端を持ちます。これはベーテ格子の滑らかな半円とは異なるため、金属-絶縁体クロスオーバーは異なる臨界 $U$ で起こり、金属相であってもグリーン関数の短時間側の振る舞いが異なります。
+
+### まとめと今後の課題
+
+単サイト DMFT が自己無撞着ループを閉じるために必要とするのは、格子の局所状態密度（あるいは分散関係）だけであり、実空間の完全な幾何学的構造ではありません──それが事前生成されたヒストグラム（`DOSFILE`）から来るか、ライブな k 空間 Hilbert 変換（`TWODBS`）から来るかを問いません。
+
+1. DMFT の計算には、正確にはどのような格子の情報が入ってくるでしょうか。例えば Ising 模型に対する古典的な（Weiss）平均場理論には何が入ってくるかと比較してみてください。単サイト DMFT 自体が平均場理論であるとは、どのような意味においてでしょうか。
+2. [DMFT-04 Mott](../dmft04) のモット転移スキャンを、ベーテ格子ではなく正方格子（`DOSFILE=DOS/DOS_Square_GRID4000` あるいは `TWODBS=1`）についてやり直してみましょう。臨界 $U$ やクロスオーバーの形に、何か顕著な変化はあるでしょうか。
+3. さまざまな空間次元における Ising 模型の平均場理論の予言を思い出してみましょう（例えば平均場臨界温度は配位数 $z$ に比例してスケールします）。ここで比較した格子の配位数（六角格子・正方格子・立方格子でそれぞれ $z=3,4,6$）は、DMFT の結果にも同様の痕跡を残すでしょうか。
+4. `tutorial8a.py`（DOSFILE）と `tutorial8b.py`（TWODBS）を同じ $U$、$\beta$ で実行し、収束した $G(\tau)$ の曲線を直接比較してみましょう。両者の一致の度合いは、DOS ヒストグラムの `GRID` 解像度と k 空間離散化 `L` にそれぞれどのように依存するでしょうか。

--- a/content/ja/tutorials/dmft/dmft09.md
+++ b/content/ja/tutorials/dmft/dmft09.md
@@ -9,241 +9,113 @@ toc: true
 
 この例では、[Georges らによる DMFT のレビュー論文](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13)の図11を再現します。この6本の曲線は、相互作用 $U=3D/\sqrt{2}$ を持つベーテ格子上の半充填 Hubbard 模型が、冷却に伴って反強磁性相へと転移していく様子を示しています。
 
-これらの例は、コマンドラインで直接コマンドを実行するか、python スクリプトを実行することで開始できます。DMFT パラメータの組の一つを手動で実行する場合、例えば `tutorials/dmft-02-hybridization` 内の `beta_14_U3_tsqrt2` ディレクトリに入り、dmft コード `/opt/alps/bin/dmft hybrid.param` を実行すると、同じ結果が得られます。
+このチュートリアルは [DMFT-02 Hybridization](../dmft02)、[DMFT-03 Interaction](../dmft03)、[DMFT-07 Hirsch-Fye](../dmft07) を統合したものです。同じ物理的な点を、アルゴリズム的に独立な3種類の不純物ソルバーで解き、その結果を1つのプロット上で直接比較します。
 
-注：この例は、チュートリアル [DMFT-02 Hybridization](../dmft02)、[DMFT-03 Interaction](../dmft03)、[DMFT-07 Hirsch-Fye](../dmft07) を統合したものです。
+### 模型
 
-### ハイブリダイゼーション展開 CT-HYB
+チュートリアル02・03・07と同様に、単バンド Hubbard 模型
 
-まず、連続時間量子モンテカルロコードであるハイブリダイゼーション展開アルゴリズム CT-HYB を実行します。CT-HYB シミュレーションは、1反復あたり約1分かかります。このシミュレーションを実行するためのパラメータファイルは、ディレクトリ `tutorials/dmft-02-hybridization` にあります。
+$$
+\hat{H} = -t\sum_{\langle i,j\rangle,\sigma} \left(\hat{c}^\dagger_{i\sigma}\hat{c}_{j\sigma} + \text{h.c.}\right) + U\sum_i \hat{n}_{i\uparrow}\hat{n}_{i\downarrow} - \mu\sum_{i,\sigma}\hat{n}_{i\sigma}
+$$
 
-主なパラメータは以下の通りです。
+をベーテ格子上、半充填（$\mu=0$）で解きます。$t=0.707106781186547=1/\sqrt{2}$（半バンド幅 $D=2t=\sqrt{2}$）、$U=3$ とすることで、[Georges et al. (1996)](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13) と同様に $U=3D/\sqrt{2}$ となります。`ANTIFERROMAGNET=1` によりネール自己無撞着が可能になっているため、この点を様々な $\beta$ にわたって冷却することで、どの不純物ソルバーを使っても同じ図11の金属-反強磁性絶縁体クロスオーバーが再現されます。
 
-```
-SEED = 0;                    // Monte Carlo Random Number Seed
-THERMALIZATION = 1000;       // Thermalization Sweeps
-SWEEPS = 100000000;          // Total Sweeps to be computed
-MAX_TIME = 60;               // Maximum time to run the simulation
-BETA = 12.;                  // Inverse temperature
-SITES = 1;                   // This is a single site DMFT simulation, so Sites is 1
-N = 1000;                    // auxiliary discretization of the imaginary-time Green's function
-NMATSUBARA = 1000;           // The number of Matsubara frequencies
-U = 3;                       // Interaction energy
-t = 0.707106781187;          // hopping parameter. For the Bethe lattice considered here $W=2D=4t$
-MU = 0;                      // Chemical potential
-H = 0;                       // Magnetic field
-SYMMETRIZATION = 0;          // We are not enforcing a paramagnetic self consistency condition
-SOLVER = Hybridization;      // The Hybridization solver
-```
+### パラメータ
 
-コマンドラインでシミュレーションを開始するには、次のように入力します。
+各ソルバーの完全な注釈付きパラメータファイルは、対応するチュートリアルに記載されています。ここでは、共通点 $\beta=12$ において、ソルバーごとに異なる設定のみを再掲します。
+
+| パラメータ | 意味 | CT-HYB（[DMFT-02](../dmft02)） | CT-INT（[DMFT-03](../dmft03)） | Hirsch-Fye（[DMFT-07](../dmft07)） |
+| :-------- | :------ | :----------------------------- | :----------------------------- | :---------------------------------- |
+| `SOLVER` | 不純物ソルバー | `"hybridization"` | `"Interaction Expansion"` | `"hirschfye"` |
+| `N` | 虚時間離散化数 | $250$ | $500$ | $16$（意図的に小さい。[DMFT-07](../dmft07#手法の選択) 参照） |
+| ソルバー固有 | 追加パラメータ | `N_MEAS`、`N_ORDER`、`SC_WRITE_DELTA` | `ALPHA`、`HISTOGRAM_MEASUREMENT` | `TOLERANCE` |
+| 共通 | `U`、`t`、`BETA`、`MU`、`H`、`FLAVORS`、`ANTIFERROMAGNET`、`SYMMETRIZATION`、`NMATSUBARA`、`OMEGA_LOOP`、`SITES`、`SEED` | 3つのソルバーすべてで共通（上の「模型」を参照） | | |
+
+### シミュレーションの実行
+
+各ソルバーの短縮版スクリプトは、それぞれ自分のチュートリアルディレクトリに `parm_beta_6.0` と `parm_beta_12.0` を書き出し、実行します。
 
 ```
-dmft hybrid.param
+cd tutorials/dmft-02-hybridization && python tutorial2.py    # CT-HYB
+cd tutorials/dmft-03-interaction   && python tutorial3.py    # CT-INT
+cd tutorials/dmft-07-hirschfye     && python tutorial7.py    # Hirsch-Fye
 ```
 
-このコードは最大10回の自己無撞着反復を実行します。プログラムを実行したディレクトリの出力先には、グリーン関数ファイル G_tau_i、自己エネルギー（selfenergy_i）、周波数空間でのグリーン関数 G_omega_i が見つかります。これらの例における G_tau はスピンアップとスピンダウンの2列から成ります。$\beta$ における値は負の密度であり、これが誤差の範囲を超えて異なる場合、系は反強磁性相にあります。python シェルで以下の行を実行することで、異なる $\beta$ に対するグリーン関数をプロットし、結果を [Georges ら](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13)の図11と比較できます。以下の Hirsch-Fye の節では、離散時間量子モンテカルロコードである Hirsch Fye コードを用いて同じ結果を再現します。求解器に対するコマンドを除いて、パラメータは同じです。
-
-例の中の `tutorials/dmft-02-hybridization` ディレクトリに、（\*tsqrt2 という名前の）パラメータファイルがあります。あるいは、python スクリプト `tutorial2a.py` を実行することもできます。
+あるいは、パラメータファイルが生成された後であれば、コマンドラインで直接次のように実行することもできます。
 
 ```
-import pyalps
-import numpy as np
-import matplotlib.pyplot as plt
-import pyalps.pyplot
-
-#prepare the input parameters
-parms=[]
-for b in [6.,8.,10.,12.,14.,16.]:
-    parms.append(
-        {
-            'ANTIFERROMAGNET'     : 1,
-            'CONVERGED'           : 0.03,
-            'F'                   : 10,
-            'FLAVORS'             : 2,
-            'H'                   : 0,
-            'H_INIT'              : 0.2,
-            'MAX_IT'              : 10,
-            'MAX_TIME'            : 60,
-            'MU'                  : 0,
-            'N'                   : 1000,
-            'NMATSUBARA'          : 1000,
-            'N_FLIP'              : 0,
-            'N_MEAS'              : 10000,
-            'N_MOVE'              : 0,
-            'N_ORDER'             : 50,
-            'N_SHIFT'             : 0,
-            'OMEGA_LOOP'          : 1,
-            'OVERLAP'             : 0,
-            'SEED'                : 0,
-            'SITES'               : 1,
-            'SOLVER'              : 'Hybridization',
-            'SYMMETRIZATION'      : 0,
-            'TOLERANCE'           : 0.01,
-            'U'                   : 3,
-            't'                   : 0.707106781186547,
-            'SWEEPS'              : 100000000,
-            'THERMALIZATION'      : 1000,
-            'BETA'                : b,
-            'CHECKPOINT'          : 'solverdump_beta_'+str(b)+'.task1.out.h5',
-            'G0TAU_INPUT'         : 'G0_tau_input_beta_'+str(b)
-        }
-    )
-#write the input file and run the simulation
-for p in parms:
-    input_file = pyalps.writeParameterFile('parm_beta_'+str(p['BETA']),p)
-    res = pyalps.runDMFT(input_file)
+/path-to-alps-installation/bin/dmft tutorials/dmft-02-hybridization/parm_beta_12.0
+/path-to-alps-installation/bin/dmft tutorials/dmft-03-interaction/parm_beta_12.0
+/path-to-alps-installation/bin/dmft tutorials/dmft-07-hirschfye/parm_beta_12.0
 ```
 
-これらのシミュレーションを実行した後、出力結果を Hirsch Fye の節や DMFT のレビュー論文の Hirsch-Fye の結果、あるいは Interaction Expansion CT-INT の節の相互作用展開の結果と比較してください。シミュレーションを再実行するには、入力パラメータ G0OMEGA_INPUT を指定することで初期解を与えることができます。例えば G0omga_output を G0_omega_input にコピーし、パラメータファイルで G0OMEGA_INPUT = G0_omega_input と指定してから、コードを再実行してください。次のスクリプトを使ってグリーン関数をプロットすることで、反強磁性相への転移を観察できます。
+完全なスクリプトと注釈付きパラメータファイルについては、[DMFT-02](../dmft02#シミュレーションの実行)、[DMFT-03](../dmft03#シミュレーションの実行)、[DMFT-07](../dmft07#シミュレーションの実行) を参照してください。
+
+### 格子
+
+3つのソルバーはすべて、このシリーズ全体で使われている、無限配位数 $z\to\infty$ の極限のベーテ格子上で実行されます。ホッピングは $t=t^*/\sqrt{z}$ とスケールされ、半円形状態密度（半バンド幅 $D=2t$）が自己無撞着ループで解析的に評価されます。
 
 ```
-flavors=parms[0]['FLAVORS']
-listobs=[]   
-for f in range(0,flavors):
-    listobs.append('Green_'+str(f))
-
-ll=pyalps.load.Hdf5Loader()
-data = ll.ReadMeasurementFromFile(pyalps.getResultFiles(pattern='parm_beta_*h5'), respath='/simulation/results/G_tau', measurements=listobs, verbose=True)
-for d in pyalps.flatten(data):
-    d.x = d.x*d.props["BETA"]/float(d.props["N"])
-    d.props['label'] = r'$\beta=$'+str(d.props['BETA'])
-plt.figure()
-plt.xlabel(r'$\tau$')
-plt.ylabel(r'$G(\tau)$')
-plt.title('Hubbard model on the Bethe lattice')
-pyalps.pyplot.plot(data)
-plt.legend()
-plt.show()
+        o       o
+         \     /
+      t   \   /   t
+           \ /
+        o---o---o          o : lattice site, interaction U (on site)
+           / \              --- : bond, hopping amplitude t
+          /   \
+         /     \
+        o       o
 ```
 
-結果には比較的大きなノイズが見られることに気づくでしょう。これは、このような高温では展開次数が非常に小さくなり、測定手順の効率が下がるためです。統計精度は、総実行時間（MAX_TIME）を増やすか、複数の CPU で実行することで改善できます。MPI で実行するには、`mpirun -np procs dmft parameter_file` を試すか、お使いの MPI 環境の man ページを参照してください。
+異なる格子で同じ比較を行う方法については、[DMFT-08 格子](../dmft08) を参照してください。
 
-DMFT の自己無撞着計算の収束を確認したい場合は、`tutorial2b.py` を使って各反復ステップのグリーン関数をプロットできます。
+### 手法の選択
 
-```
-ll=pyalps.load.Hdf5Loader()
-for p in parms:
-    data = ll.ReadDMFTIterations(pyalps.getResultFiles(pattern='parm_beta_'+str(p['BETA'])+'.h5'), measurements=listobs, verbose=True)
-    grouped = pyalps.groupSets(pyalps.flatten(data), ['iteration'])
-    nd=[]
-    for group in grouped:
-        r = pyalps.DataSet()
-        r.y = np.array(group[0].y)
-        r.x = np.array([e*group[0].props['BETA']/float(group[0].props['N']) for e in group[0].x])
-        r.props = group[0].props
-        r.props['label'] = r.props['iteration']
-        nd.append( r )
-    plt.figure()
-    plt.xlabel(r'$\tau$')
-    plt.ylabel(r'$G(\tau)$')
-    plt.title(r'\beta = %.4s' %nd[0].props['BETA'])
-    pyalps.pyplot.plot(nd)
-    plt.legend()
-    plt.show()
-```
+CT-HYB、CT-INT、Hirsch-Fye は、互いに無関係な近似の上に構築されています。CT-HYB はハイブリダイゼーションを展開し、強結合で最も効率が良く、CT-INT は相互作用を展開し、弱〜中程度の結合で最も効率が良く、Hirsch-Fye は虚時間を $N$ 個のスライスに離散化し、外挿によって取り除く必要のある系統的な $(\Delta\tau)^2$ バイアスを持ちます（それぞれの詳細については [DMFT-02](../dmft02)、そして [DMFT-03](../dmft03#手法の選択) と [DMFT-07](../dmft07#手法の選択) の「手法の選択」の節を参照してください）。$U=3D/\sqrt{2}$ では、これら3つのアルゴリズムのいずれにとっても明らかに有利あるいは不利な領域で動作しているわけではないため、この点は互いを相互チェックするのに良い場所になります。3つのソルバーは共通の系統誤差を持たないため、収束した3つの結果すべてに現れる特徴──特に、冷却に伴う $G(\tau)$ の反強磁性的な分裂──は、特定のモンテカルロアルゴリズムの産物ではなく、物理模型と DMFT の自己無撞着性そのものの性質であるはずです。
 
-収束の様子は、より変化に敏感な自己エネルギーで観察するのが最良です。より滑らかなグリーン関数や自己エネルギーを得るには、より長いシミュレーションが必要であることに注意してください。
+### 出力データとプロット
 
-### 相互作用展開 CT-INT
-
-Hybridization Expansion CT-HYB の節と同じ計算を CT-INT コードで行ってみると勉強になります。このコードは（ハイブリダイゼーションではなく）相互作用を展開します。対応するパラメータファイルは非常によく似ており、ディレクトリ `tutorials/dmft-03-interaction` にあります。python でシミュレーションを実行したい場合は、`tutorial3a.py` および `tutorial3b.py` ファイルを使用できます。
-
-### Hirsch Fye
-
-離散時間モンテカルロコードである [Hirsch Fye コード](https://link.aps.org/doi/10.1103/PhysRevLett.56.2521)を実行し、連続時間の結果と比較します。Hirsch Fye アルゴリズムは[こちら](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13)で解説されており、このレビュー論文はコードのオープンソース実装も提供しています。これまでに多くの改良が行われてきましたが（例えば Alvarez (2008) や [Nukala09](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.80.195111) を参照してください）、このアルゴリズムは[連続時間アルゴリズム](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.76.235123)に取って代わられました。
-
-Hirsch Fye シミュレーションは、1反復あたり約1分かかります。このシミュレーションを実行するためのパラメータファイルは、[このチュートリアル](../dmft07)にあります。
-
-主なパラメータは以下の通りです。
-
-```
-SEED = 0;                    // Monte Carlo Random Number Seed
-THERMALIZATION = 10000;      // Thermalization Sweeps
-SWEEPS = 1000000;            // Total Sweeps to be computed
-MAX_TIME = 60;               // Maximum time to run the simulation
-BETA = 12.;                  // Inverse temperature
-SITES = 1;                   // This is a single site DMFT simulation, so Sites is 1
-N = 16;                      // Number of time slices (you will see that this parameter is rather small)
-NMATSUBARA = 500;            // The number of Matsubara frequencies
-U = 3;                       // Interaction energy
-t = 0.707106781187;          // hopping parameter. For the Bethe lattice considered here $W=2D=4t$
-MU = 0;                      // Chemical potential
-H = 0;                       // Magnetic field
-SYMMETRIZATION = 0;          // We are not enforcing a paramagnetic self consistency condition
-SOLVER = /opt/alps/bin/hirschfye;  // The path to the external Hirsch Fye solver
-```
-
-シミュレーションを開始するには、次のように入力します。
-
-```
-dmft hirschfye.param
-```
-
-あるいは、python スクリプト `tutorial7a.py` を実行します。
+（チュートリアル02・03・07のように）各ソルバーの結果を別々にプロットするのではなく、このチュートリアルの主眼は、3つすべてを同じ図の上に重ねて表示することにあります。
 
 ```
 import pyalps
 import numpy as np
 import matplotlib.pyplot as plt
-import pyalps.pyplot
+import pyalps.plot
 
-#prepare the input parameters 
-parms=[]
-for b in [6.,8.,10.,12.,14.,16.]: 
-    parms.append(
-        { 
-            'ANTIFERROMAGNET'     : 1,
-            'CONVERGED'           : 0.03,
-            'FLAVORS'             : 2,
-            'H'                   : 0,
-            'MAX_IT'              : 10,
-            'MAX_TIME'            : 60,
-            'MU'                  : 0,
-            'N'                   : 16,
-            'NMATSUBARA'          : 500, 
-            'OMEGA_LOOP'          : 1,
-            'SEED'                : 0, 
-            'SITES'               : 1,
-            'SOLVER'              : '/opt/alps/bin/hirschfye',
-            'SYMMETRIZATION'      : 0,
-            'TOLERANCE'           : 0.01,
-            'U'                   : 3,
-            't'                   : 0.707106781186547,
-            'SWEEPS'              : 1000000,
-            'THERMALIZATION'      : 10000,
-            'BETA'                : b,
-            'G0OMEGA_INPUT'       : 'G0_omega_input_beta_'+str(b),
-            'BASENAME'            : 'hirschfye.param'
-        }
-    )
+listobs = ['0']  # flavor 0
 
-#write the input file and run the simulation
-for p in parms:
-    input_file = pyalps.writeParameterFile('parm_beta_'+str(p['BETA']),p)
-    res = pyalps.runDMFT(input_file)
-```
+files = {
+    'CT-HYB'     : 'tutorials/dmft-02-hybridization/parm_beta_12.0.h5',
+    'CT-INT'     : 'tutorials/dmft-03-interaction/parm_beta_12.0.h5',
+    'Hirsch-Fye' : 'tutorials/dmft-07-hirschfye/parm_beta_12.0.h5',
+}
 
-このコードは最大10回の自己無撞着反復を実行します。プログラムを実行したディレクトリの出力先には、グリーン関数ファイル G_tau_i、自己エネルギー（selfenergy_i）、周波数空間でのグリーン関数 G_omega_i が見つかります。これらの例における G_tau はスピンアップとスピンダウンの2列から成ります。$\beta$ における値は負の密度であり、これが誤差の範囲を超えて異なる場合、系は反強磁性相にあります。python シェルで以下の行を実行することで、異なる $\beta$ に対するグリーン関数をプロットし、結果を [Georges ら](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13)の図11と比較できます。
+alldata = []
+for solver, fname in files.items():
+    data = pyalps.loadMeasurements([fname], respath='/simulation/results/G_tau', what=listobs, verbose=False)
+    for d in pyalps.flatten(data):
+        d.x = d.x*d.props["BETA"]/float(d.props["N"])
+        d.props['label'] = solver
+        alldata.append(d)
 
-```
-flavors=parms[0]['FLAVORS']
-listobs=[]   
-for f in range(0,flavors):
-    listobs.append('Green_'+str(f))
-
-ll=pyalps.load.Hdf5Loader()
-data = ll.ReadMeasurementFromFile(pyalps.getResultFiles(pattern='parm_beta_*h5'), respath='/simulation/results/G_tau', measurements=listobs, verbose=True)
-for d in pyalps.flatten(data):
-    d.x = d.x*d.props["BETA"]/float(d.props["N"])
-    d.props['label'] = r'$\beta=$'+str(d.props['BETA'])
 plt.figure()
 plt.xlabel(r'$\tau$')
-plt.ylabel(r'$G(\tau)$')
-plt.title('Hubbard model on the Bethe lattice')
-pyalps.pyplot.plot(data)
+plt.ylabel(r'$G_{flavor=0}(\tau)$')
+plt.title('DMFT-09: Neel transition at BETA=12, solver comparison')
+pyalps.plot.plot(alldata)
 plt.legend()
 plt.show()
 ```
 
-離散時間法であるため、HF は $\Delta\tau$ による離散化誤差の影響を受けます。パラメータの組を一つ選び、$N$ を徐々に大きくしながら実行してみてください。また、ここでは（ほぼ）収束した入力バス関数を用いて DMFT シミュレーションを実行していることに注意してください。ファイル G0_omega_input を削除すると、自由解から計算を再開し、収束の様子を観察することができます。
+これは3つの独立な確率的シミュレーションを比較するものであるため、実際に得られる数値はそれぞれの実行の `SEED`、`MAX_TIME`、計算機の速度に依存しますが、3本の曲線は、それぞれの誤差範囲内で一致するはずです──ただし、[DMFT-07](../dmft07#まとめと今後の課題) で提案されているように外挿しない限り、Hirsch-Fye の `N=16` による離散化バイアスは CT-HYB や CT-INT との比較で目に見える形で現れます。ソルバーを最初からではなく部分的に収束した解から再実行することもできます：目的の `G0omega_output` を新しいファイル名にコピーし、再実行する前にパラメータファイル（あるいは対応する python の辞書）で `G0OMEGA_INPUT` を指定してください。
+
+### まとめと今後の課題
+
+同じネール転移を CT-HYB、CT-INT、Hirsch-Fye で解き、3つすべてが一致することを確認することは、DMFT-02・DMFT-03・DMFT-07 がソルバー固有のアーティファクトではなく、同じ物理へと収束していることを直接確認する手段になります。
+
+1. 上記の統合プロットを（`tutorial2_long.py`、`tutorial3_long.py`、`tutorial7_long.py` を用いて）$\beta$ の6つの値すべてに拡張し、各温度で3つのソルバーすべてを重ねた、図11との完全な比較を再現してみましょう。
+2. 固定した実行時間のもとで、$\beta=12$ において3つのソルバーのうちどれが最も小さい誤差棒を与えるでしょうか。系がより常磁性側に近い $\beta=6$ では、その順位は変わるでしょうか。
+3. Hirsch-Fye の結果を統合プロットに含める前に、$\Delta\tau\to0$ へ外挿してみましょう（[DMFT-07](../dmft07#まとめと今後の課題) 参照）。外挿した曲線は、CT-HYB や CT-INT に目に見えて近づくでしょうか。
+4. [DMFT-06](../dmft06) では、常磁性金属相において、[Georges et al. (1996)](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13) の図15にある厳密対角化／Hirsch-Fye のベンチマークと比較する、類似のソルバー間比較を行っています。この2つの比較を見比べてみましょう：ソルバー間の一致は、チュートリアル06の常磁性金属とここで扱った反強磁性相のどちらでより得やすいでしょうか。

--- a/content/zh-cn/tutorials/dmft/dmft08.md
+++ b/content/zh-cn/tutorials/dmft/dmft08.md
@@ -7,11 +7,87 @@ toc: true
 
 ## Setting a particular lattice
 
+之前所有的教程处理的都是具有半圆形态密度（DOS）的贝特格子，这使得自洽循环在解析上很简单（$\Omega$ 循环，不需要 k 空间积分）。但真实材料存在于正方格子、立方格子、六角格子或更复杂的格子之上，其态密度带有范霍夫奇点和硬带边，而不是光滑的半圆。这些特征会改变 Mott 转变发生的位置，或其转变的陡峭程度，因此了解如何针对贝特格子以外的格子运行单点 DMFT 是很有用的。本教程展示了具体做法；你可以直接复用前面教程中的脚本（例如 [DMFT-04 Mott](../dmft04) 中的 Mott 转变扫描），只需替换为下文引入的格子专属参数即可。
+
+### 模型
+
+格点哈密顿量仍然是单带 Hubbard 模型
+
+$$
+\hat{H} = -\sum_{\langle i,j\rangle,\sigma} t_{ij}\left(\hat{c}^\dagger_{i\sigma}\hat{c}_{j\sigma} + \text{h.c.}\right) + U\sum_i \hat{n}_{i\uparrow}\hat{n}_{i\downarrow} - \mu\sum_{i,\sigma}\hat{n}_{i\sigma},
+$$
+
+只是现在 $t_{ij}$ 取遍所选格子的各条键，而不是贝特格子 $z\to\infty$ 的树状结构。然而在单点 DMFT 中，格子从不直接进入杂质问题：自洽计算只需要局域的、对 k 积分后的非相互作用态密度 $\rho_0(\epsilon)=\sum_{\mathbf{k}}\delta(\epsilon-\epsilon_{\mathbf{k}})$（或者，如果 Hilbert 变换在 k 空间中实时进行，则等价地只需要色散关系 $\epsilon_{\mathbf{k}}$）。这正是经典平均场理论用单一有效（依赖于配位数的）场取代完整格子几何结构的 DMFT 类比。关于以 $\rho_0(\epsilon)$ 表示的自洽条件的一般推导，参见 [Georges et al. (1996)](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13)。
+
+### 参数
+
+以下两种方法共有的参数（取自 `tutorial8a.py`／`tutorial8b.py` 中所用的值）：
+
+| 参数 | 含义 | 所用取值 |
+| :-------- | :------ | :------------ |
+| `U` | 在位相互作用 | $3$ |
+| `BETA` | 逆温度 | $6$ |
+| `MU` | 化学势 | $0$（半满） |
+| `H`, `H_INIT` | 量子化轴方向的磁场／初始外斯场的种子场 | $0$ / $0.05$ |
+| `FLAVORS` | 自旋味的数目 | $2$ |
+| `SITES` | 杂质格点数 | $1$ |
+| `ANTIFERROMAGNET` | 启用 Néel 自洽 | $1$ |
+| `SYMMETRIZATION` | 是否强制顺磁解 | $0$ |
+| `N`, `NMATSUBARA` | $G$ 与 $G_0$ 的虚时间／松原频率离散化数目 | $500$ |
+| `OMEGA_LOOP` | 在松原频率下进行自洽计算 | $1$ |
+| `G0OMEGA_INPUT` | 设为空字符串，强制从非相互作用格林函数计算初始外斯场 | `""` |
+| `MAX_IT`, `CONVERGED` | 自洽迭代的最大次数／收敛判据 | $10$、$0.005$ |
+| `SOLVER` | 杂质求解器 | `"hybridization"`（CT-HYB） |
+| `SC_WRITE_DELTA`, `N_MEAS`, `N_ORDER` | 写出杂化函数／测量之间的蒙特卡罗更新次数／展开阶数直方图的大小 | $1$、$5000$、$50$ |
+| `SWEEPS`, `THERMALIZATION`, `MAX_TIME` | 蒙特卡罗扫描数上限／热化扫描数／每次迭代的实际时间上限（秒） | $10^4$、$500$、$60$ |
+
+### 格子
+
+有两种格子专属的机制可用；二者都会将对 k 积分后的态密度输入同一个自洽循环。
+
+**DOSFILE**：只要提供该格子的态密度表，就可以使用*任意*格子。本教程内置了四种格子的预生成 DOS 表（直方图），跃迁均归一化为 $t=1$：
+
+- **正方格子**（`DOS_Square_GRID4000`，配位数 $z=4$，二阶矩 `EPSSQ_i=4`）：
+  ```
+  o---o---o
+  |   |   |
+  o---o---o        o : lattice site, interaction U (on site)
+  |   |   |        --- , | : bond, nearest-neighbor hopping t
+  o---o---o
+  ```
+- **立方格子**（`DOS_Cubic_GRID360`，配位数 $z=6$，二阶矩 `EPSSQ_i=6`）：是上面正方格子向三维的推广，每个方向都额外增加了一条跃迁为 $t$、垂直于纸面的键。
+- **六角（蜂窝）格子**（`DOS_Hexagonal_GRID4000`，配位数 $z=3$，二阶矩 `EPSSQ_i=3`）：
+  ```
+        o---o       o---o
+       /     \     /     \
+      o       o---o       o     o : lattice site, interaction U (on site)
+       \     /     \     /      --- , / , \ : bond, nearest-neighbor hopping t
+        o---o       o---o
+  ```
+- **贝特格子**（`DOS_Bethe`，二阶矩 `EPSSQ_i=1`，内置用于测试）：与教程 02–07 中使用的格子相同，此处作为参考展示：
+  ```
+          o       o
+           \     /
+        t   \   /   t
+             \ /
+          o---o---o          o : lattice site, interaction U (on site)
+             / \              --- : bond, hopping amplitude t
+            /   \
+           /     \
+          o       o
+  ```
+
+每个 DOS 表都是由一个小型直方图生成脚本——[`DOS_Square.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Square.py)（`GRID=4000`）、[`DOS_Cubic.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Cubic.py)（`GRID=360`）、[`DOS_Hexagonal.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Hexagonal.py)（`GRID=4000`）——通过在 `GRID`$\times$`GRID` 的 k 点网格上对紧束缚色散在整个布里渊区做积分而生成的。你也可以用同样的方法为任何其他格子生成 DOS 表，或者在构建自己的格子时，参考 [ALPS 格子库](../../../documentation/intro/latticehowtos) 了解格子几何结构和配位数。
+
+**TWODBS**：对于正方格子和六角格子，ALPS 可以不依赖预先制表的 DOS 文件，而是在每一步自洽计算中，将 Hilbert 变换直接作为实时的 k 空间积分（在 $L\times L$ 的 k 点网格上离散化）来求值。
+
+### 方法选择
+
+`DOSFILE` 与 `TWODBS` 在通用性与便利性之间做了不同的取舍。`DOSFILE` 适用于*任意*格子，因为只需要对 $\rho_0(\epsilon)$ 做一次性的直方图统计（如上文 `DOS_Square.py` 那样的脚本生成一次即可）——但其精度受限于直方图的 `GRID` 分辨率和分箱数，并且一旦跃迁参数发生变化就必须重新生成。`TWODBS` 在 k 空间离散化 `L` 的范围内是精确的，也不需要单独的预处理步骤，但目前仅针对正方格子（最近邻跃迁 `t` 与次近邻跃迁 `tprime`）和六角格子（仅最近邻跃迁 `t`）实现——完整参数列表参见 [DMFT 参数参考](../../../documentation/methods/dmft)。无论哪种情况，能够到达杂质求解器的格子信息都只有 $\rho_0(\epsilon)$（通过 `DOSFILE`）或 $\epsilon_{\mathbf k}$（通过 `TWODBS`），以及它们的一阶、二阶矩 `EPS_i`、`EPSSQ_i`——这印证了上文“模型”一节中的论点：单点 DMFT 只能通过（积分后的）非相互作用色散关系“看到”格子。
+
 ### Option DOSFILE
 
-之前所有的教程处理的都是具有半圆形态密度的贝特格子。现在我们展示如何设置输入参数，以指定某个特定格子的态密度。要运行模拟，你可以直接使用之前教程中的脚本，只需替换参数列表即可进行类似的模拟。例如，你可以像 [DMFT-04 Mott](../dmft04) 中那样考察 MIT。
-
-对于一般的格子，你需要提供该格子的态密度。除此之外，还需要做一些其他修改才能运行模拟。下面是一个可用的 python 脚本 [`tutorial8a.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/tutorial8a.py)，用于设置输入文件并运行模拟：
+对于一般的格子，你需要提供该格子的态密度。除此之外，还需要做一些其他修改才能运行模拟。下面是一个可用的 python 脚本 [`tutorial8a.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/tutorial8a.py)，用于设置输入文件、运行模拟并绘制结果：
 
 ```
 import pyalps
@@ -61,9 +137,30 @@ for u in [3.]:
 for p in parms:
     input_file = pyalps.writeParameterFile('hybrid_DOS_beta_'+str(p['BETA'])+'_U_'+str(p['U']),p)
     res = pyalps.runDMFT(input_file)
+
+listobs=['0']  # we look only at flavor=0
+    
+data = pyalps.loadMeasurements(pyalps.getResultFiles(pattern='hybrid_DOS*h5'), respath='/simulation/results/G_tau', what=listobs, verbose=True)
+for d in pyalps.flatten(data):
+    d.x = d.x*d.props["BETA"]/float(d.props["N"])
+    d.props['label'] = r'$\beta=$'+str(d.props['BETA'])
+plt.figure()
+
+plt.xlabel(r'$\tau$')
+plt.ylabel(r'$G_{flavor=0}(\tau)$')
+plt.title('DMFT-08, DOS-based approach: Hubbard model on the square lattice')
+pyalps.plot.plot(data)
+plt.legend()
+plt.show()
 ```
 
-输入文件中出现的与格子相关的参数如下：
+在内部，`pyalps.runDMFT` 会针对生成的参数文件直接调用 `dmft` 应用程序：
+
+```
+/path-to-alps-installation/bin/dmft hybrid_DOS_beta_6.0_U_3.0
+```
+
+上述脚本生成的输入文件 `hybrid_DOS_beta_6.0_U_3.0` 中，格子专属的参数为
 
 ```
 DOSFILE = DOS/DOS_Square_GRID4000; // specification of the file with density of states
@@ -74,16 +171,13 @@ EPSSQ_0 = 4;                      // the second moment of the bandstructure for 
 EPSSQ_1 = 4;                      // the second moment of the bandstructure for the flavor 1
 ```
 
+再加上上面参数表中列出的物理／求解器参数。注意这里最近邻跃迁并不是一个显式参数——它已经被固化在 DOS 表本身之中，而 `DOS_Square.py` 在构造该表时将其固定为 $t=1$。
+
 注 1：如果在输入文件中不提供能带结构参数（EPS_i、EPSSQ_i），那么它们将根据给定的 DOS 计算得到（自 revision 6146 起），公式为 $EPS_{flavor=i} = \int \mathrm{d}\epsilon\ DOS_{band=i/2}(\epsilon)\ \epsilon$，$EPSSQ_{flavor=i} = \int \mathrm{d}\epsilon\ DOS_{band=i/2}(\epsilon)\ \epsilon^2$。
 
 注 2：反铁磁自洽循环假定为 Néel 序，因此仅适用于二分格子（bipartite lattices）。
 
-注 3：态密度必须由用户自行提供。本教程提供了以下几种态密度：
-
-- 正方格子 DOS_Square_GRID4000（由 [`DOS_Square.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Square.py) 在 GRID=4000 的设置下生成）；对应参数为 EPSSQ_i=4
-- 立方格子 DOS_Cubic_GRID360（由 [`DOS_Cubic.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Cubic.py) 在 GRID=360 的设置下生成）；对应参数为 EPSSQ_i=6
-- 六角格子 DOS_Hexagonal_GRID4000（由 [`DOS_Hexagonal.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/DOS/DOS_Hexagonal.py) 在 GRID=4000 的设置下生成）；对应参数为 EPSSQ_i=3
-- 贝特格子 DOS_Bethe（由 `DOS_Bethe.py` 生成）；对应参数为 EPSSQ_i=1；用于测试
+注 3：态密度必须由用户自行提供。本教程提供了上文“格子”一节中列出的正方格子、立方格子、六角格子与贝特格子的态密度。
 
 注 4：对于已知 DOS 的多带模拟 [$n_{\text{bands}}=FLAVORS/2$]，DOS 文件必须包含 $2n_{\text{bands}}$ 列。所有能带的分箱数（即输入文件的行数）必须相同。第 $i$ 行的结构如下所示
 
@@ -98,7 +192,7 @@ $$
 - 正方格子 [设置 TWODBS=square]，具有最近邻 [对应参数：t] 和次近邻跳跃 [对应参数：tprime]；二阶矩 EPSSQ_i 为 $4(t^2 + tprime^2)$；
 - 六角格子 [设置 TWODBS=hexagonal]，仅具有最近邻跳跃 [对应参数：t]；二阶矩 EPSSQ_i 为 $3t^2$。
 
-下面是一个用于生成输入文件并运行模拟的可用 python 脚本 [`tutorial8b.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/tutorial8b.py)：
+下面是一个用于生成输入文件、运行模拟并绘制结果的可用 python 脚本 [`tutorial8b.py`](https://github.com/ALPSim/ALPS/blob/daa73925b95389c0ec5e0d76ce592b56f3cd6738/tutorials/dmft-08-lattices/tutorial8b.py)：
 
 ```
 import pyalps
@@ -151,9 +245,28 @@ for u in [3.]:
 for p in parms:
     input_file = pyalps.writeParameterFile('hybrid_TWODBS_beta_'+str(p['BETA'])+'_U_'+str(p['U']),p)
     res = pyalps.runDMFT(input_file)
+
+listobs=['0']  # we look only at flavor=0
+    
+data = pyalps.loadMeasurements(pyalps.getResultFiles(pattern='hybrid_TWODBS*h5'), respath='/simulation/results/G_tau', what=listobs, verbose=True)
+for d in pyalps.flatten(data):
+    d.x = d.x*d.props["BETA"]/float(d.props["N"])
+    d.props['label'] = r'$\beta=$'+str(d.props['BETA'])
+plt.figure()
+
+plt.xlabel(r'$\tau$')
+plt.ylabel(r'$G_{flavor=0}(\tau)$')
+plt.title('DMFT-08, TWODBS option: Hubbard model on the square lattice')
+pyalps.plot.plot(data)
+plt.legend()
+plt.show()
 ```
 
-与格子相关的参数如下：
+```
+/path-to-alps-installation/bin/dmft hybrid_TWODBS_beta_6.0_U_3.0
+```
+
+生成的输入文件 `hybrid_TWODBS_beta_6.0_U_3.0` 中，格子专属的参数如下：
 
 ```
 TWODBS = 1;     // the Hilbert transformation integral runs in k-space; sets square lattice
@@ -167,10 +280,19 @@ EPSSQ_0 = 4;                   // the second moment of the bandstructure for the
 EPSSQ_1 = 4;                   // the second moment of the bandstructure for the flavor 1
 ```
 
-### Final remarks
+这里 `t=1`、`tprime=0` 是显式给出的参数（不同于 DOSFILE 方式中跃迁被固定在预先制表的文件里），因此 `EPSSQ_i=4(t^2+tprime^2)=4` 可以直接由上面的公式得出。
 
-问题：哪些格子信息会进入 DMFT 计算？与经典平均场进行比较。
+### 输出数据与绘图
 
-任务：尝试针对（贝特格子以外的）另一种格子重复 [DMFT-04 Mott](../dmft04) 中的计算，并考察 MIT。是否出现了明显的变化？
+`tutorial8a.py`（DOSFILE）与 `tutorial8b.py`（TWODBS）都以前面教程中同样的绘图方式结尾：自洽循环结束时的虚时间格林函数 $G_{\text{flavor}=0}(\tau)$，这里是 $U=3$、$\beta=6$ 时正方格子的结果。由于两个脚本针对的是同一个格子（正方格子，$t=1$）和同一个物理点，它们收敛后的 $G(\tau)$ 应在统计误差范围内彼此一致——这是检验 DOSFILE 直方图与 TWODBS 实时 k 空间积分是否描述同一物理的一个有用交叉验证。
 
-回顾 Ising 模型在不同维度下的平均场预测。
+将此结果与相同 $U$、$\beta$ 下 [DMFT-02 Hybridization](../dmft02) 和 [DMFT-04 Mott](../dmft04) 中贝特格子的结果相比较，预计会看到明显的差异：正方格子的态密度在带中心处有对数型范霍夫奇点，并在 $\epsilon=\pm4t$ 处有硬带边，这与贝特格子光滑的半圆形态密度不同，因此金属-绝缘体交叉发生在不同的临界 $U$ 处，即使在金属相中，格林函数的短时行为也会有所不同。
+
+### 小结与展望
+
+单点 DMFT 要闭合自洽循环，只需要格子的局域态密度（或色散关系），而不需要其完整的实空间几何结构——无论这个态密度来自预先制表的直方图（`DOSFILE`）还是实时的 k 空间 Hilbert 变换（`TWODBS`）。
+
+1. 究竟哪些格子信息会进入 DMFT 计算？将你的答案与经典（Weiss）平均场处理 Ising 模型时所用到的信息做比较——在什么意义上，单点 DMFT 本身也是一种平均场理论？
+2. 针对正方格子（`DOSFILE=DOS/DOS_Square_GRID4000` 或 `TWODBS=1`）而非贝特格子，重做 [DMFT-04 Mott](../dmft04) 中的 Mott 转变扫描。临界 $U$ 或转变的形状是否出现了明显变化？
+3. 回顾 Ising 模型在不同空间维度下的平均场预言（例如平均场临界温度随配位数 $z$ 标度）。这里比较的几种格子的配位数（六角、正方、立方格子分别为 $z=3,4,6$）是否在 DMFT 结果中留下了类似的痕迹？
+4. 分别用相同的 $U$、$\beta$ 运行 `tutorial8a.py`（DOSFILE）和 `tutorial8b.py`（TWODBS），直接比较收敛后的 $G(\tau)$ 曲线。二者的一致程度分别如何依赖于 DOS 直方图的 `GRID` 分辨率和 k 空间离散化 `L`？

--- a/content/zh-cn/tutorials/dmft/dmft09.md
+++ b/content/zh-cn/tutorials/dmft/dmft09.md
@@ -9,241 +9,113 @@ toc: true
 
 在本例中，我们重现 [Georges 等人的 DMFT 综述文章](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13)中的图 11。这一系列共六条曲线展示了体系——一个相互作用为 $U=3D/\sqrt{2}$、处于半满情形、格子为贝特格子的 Hubbard 模型——在降温过程中如何进入反铁磁相。
 
-这些示例既可以通过命令行直接调用命令来运行，也可以通过 python 脚本来运行。手动运行其中一组 DMFT 参数，例如进入 `tutorials/dmft-02-hybridization` 目录下的 `beta_14_U3_tsqrt2` 目录，并运行 dmft 代码 `/opt/alps/bin/dmft hybrid.param`，会得到相同的结果。
+本教程综合了 [DMFT-02 Hybridization](../dmft02)、[DMFT-03 Interaction](../dmft03) 和 [DMFT-07 Hirsch-Fye](../dmft07)：用三种算法上相互独立的杂质求解器求解同一个物理点，并将结果直接绘制在同一张图上进行比较。
 
-注：本示例综合了教程 [DMFT-02 Hybridization](../dmft02)、[DMFT-03 Interaction](../dmft03) 和 [DMFT-07 Hirsch-Fye](../dmft07) 的内容。
+### 模型
 
-### 杂化展开 CT-HYB
+与教程 02、03、07 一样，我们求解单带 Hubbard 模型
 
-我们首先运行一个连续时间量子蒙特卡罗代码：杂化展开算法 CT-HYB。CT-HYB 模拟每次迭代大约需要一分钟。运行此模拟所需的参数文件可以在目录 `tutorials/dmft-02-hybridization` 中找到。
+$$
+\hat{H} = -t\sum_{\langle i,j\rangle,\sigma} \left(\hat{c}^\dagger_{i\sigma}\hat{c}_{j\sigma} + \text{h.c.}\right) + U\sum_i \hat{n}_{i\uparrow}\hat{n}_{i\downarrow} - \mu\sum_{i,\sigma}\hat{n}_{i\sigma}
+$$
 
-主要参数如下：
+处于贝特格子上、半满（$\mu=0$）情形，取 $t=0.707106781186547=1/\sqrt{2}$（半带宽 $D=2t=\sqrt{2}$）、$U=3$，使得 $U=3D/\sqrt{2}$，与 [Georges et al. (1996)](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13) 一致。`ANTIFERROMAGNET=1` 允许 Néel 自洽，因此在一系列 $\beta$ 下冷却这一物理点，无论使用哪种杂质求解器，都会重现图 11 中金属到反铁磁绝缘体的交叉。
 
-```
-SEED = 0;                    // Monte Carlo Random Number Seed
-THERMALIZATION = 1000;       // Thermalization Sweeps
-SWEEPS = 100000000;          // Total Sweeps to be computed
-MAX_TIME = 60;               // Maximum time to run the simulation
-BETA = 12.;                  // Inverse temperature
-SITES = 1;                   // This is a single site DMFT simulation, so Sites is 1
-N = 1000;                    // auxiliary discretization of the imaginary-time Green's function
-NMATSUBARA = 1000;           // The number of Matsubara frequencies
-U = 3;                       // Interaction energy
-t = 0.707106781187;          // hopping parameter. For the Bethe lattice considered here $W=2D=4t$
-MU = 0;                      // Chemical potential
-H = 0;                       // Magnetic field
-SYMMETRIZATION = 0;          // We are not enforcing a paramagnetic self consistency condition
-SOLVER = Hybridization;      // The Hybridization solver
-```
+### 参数
 
-要通过命令行启动模拟，输入：
+每个求解器完整的注释参数文件都已在相应教程中给出；这里只在共同的 $\beta=12$ 处重新列出各求解器专属的设置：
+
+| 参数 | 含义 | CT-HYB（[DMFT-02](../dmft02)） | CT-INT（[DMFT-03](../dmft03)） | Hirsch-Fye（[DMFT-07](../dmft07)） |
+| :-------- | :------ | :----------------------------- | :----------------------------- | :---------------------------------- |
+| `SOLVER` | 杂质求解器 | `"hybridization"` | `"Interaction Expansion"` | `"hirschfye"` |
+| `N` | 虚时间离散化数 | $250$ | $500$ | $16$（刻意取小值，见 [DMFT-07](../dmft07#方法选择)） |
+| 求解器专属 | 附加参数 | `N_MEAS`、`N_ORDER`、`SC_WRITE_DELTA` | `ALPHA`、`HISTOGRAM_MEASUREMENT` | `TOLERANCE` |
+| 共有 | `U`、`t`、`BETA`、`MU`、`H`、`FLAVORS`、`ANTIFERROMAGNET`、`SYMMETRIZATION`、`NMATSUBARA`、`OMEGA_LOOP`、`SITES`、`SEED` | 三个求解器完全相同（见上文“模型”） | | |
+
+### 运行模拟
+
+每个求解器的简短版脚本都会在其各自的教程目录中写出 `parm_beta_6.0` 和 `parm_beta_12.0`，并运行它们：
 
 ```
-dmft hybrid.param
+cd tutorials/dmft-02-hybridization && python tutorial2.py    # CT-HYB
+cd tutorials/dmft-03-interaction   && python tutorial3.py    # CT-INT
+cd tutorials/dmft-07-hirschfye     && python tutorial7.py    # Hirsch-Fye
 ```
 
-程序最多运行 10 次自洽迭代。在运行程序的目录中，你会找到格林函数文件 G_tau_i、自能文件（selfenergy_i）以及频率空间下的格林函数 G_omega_i，均位于输出目录中。这些例子中的 G_tau 包含两列：自旋向上和自旋向下。$\beta$ 处的取值即为负的密度；当该值在误差棒范围之外出现差异时，体系即处于反铁磁相。你可以在 python shell 中运行以下代码，绘制不同 $\beta$ 下的格林函数，并将结果与 [Georges 等人](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13)图 11 的结果进行比较。在下面的 Hirsch-Fye 部分，我们将用离散时间量子蒙特卡罗代码——Hirsch Fye 代码——重现相同的结果。除求解器所用的命令外，其余参数都是相同的。
-
-你可以在示例中的目录 `tutorials/dmft-02-hybridization` 里找到相应的参数文件（名为 \*tsqrt2）。你也可以运行 python 脚本 `tutorial2a.py`：
+或者，在参数文件生成之后，也可以直接在命令行中运行：
 
 ```
-import pyalps
-import numpy as np
-import matplotlib.pyplot as plt
-import pyalps.pyplot
-
-#prepare the input parameters
-parms=[]
-for b in [6.,8.,10.,12.,14.,16.]:
-    parms.append(
-        {
-            'ANTIFERROMAGNET'     : 1,
-            'CONVERGED'           : 0.03,
-            'F'                   : 10,
-            'FLAVORS'             : 2,
-            'H'                   : 0,
-            'H_INIT'              : 0.2,
-            'MAX_IT'              : 10,
-            'MAX_TIME'            : 60,
-            'MU'                  : 0,
-            'N'                   : 1000,
-            'NMATSUBARA'          : 1000,
-            'N_FLIP'              : 0,
-            'N_MEAS'              : 10000,
-            'N_MOVE'              : 0,
-            'N_ORDER'             : 50,
-            'N_SHIFT'             : 0,
-            'OMEGA_LOOP'          : 1,
-            'OVERLAP'             : 0,
-            'SEED'                : 0,
-            'SITES'               : 1,
-            'SOLVER'              : 'Hybridization',
-            'SYMMETRIZATION'      : 0,
-            'TOLERANCE'           : 0.01,
-            'U'                   : 3,
-            't'                   : 0.707106781186547,
-            'SWEEPS'              : 100000000,
-            'THERMALIZATION'      : 1000,
-            'BETA'                : b,
-            'CHECKPOINT'          : 'solverdump_beta_'+str(b)+'.task1.out.h5',
-            'G0TAU_INPUT'         : 'G0_tau_input_beta_'+str(b)
-        }
-    )
-#write the input file and run the simulation
-for p in parms:
-    input_file = pyalps.writeParameterFile('parm_beta_'+str(p['BETA']),p)
-    res = pyalps.runDMFT(input_file)
+/path-to-alps-installation/bin/dmft tutorials/dmft-02-hybridization/parm_beta_12.0
+/path-to-alps-installation/bin/dmft tutorials/dmft-03-interaction/parm_beta_12.0
+/path-to-alps-installation/bin/dmft tutorials/dmft-07-hirschfye/parm_beta_12.0
 ```
 
-运行这些模拟后，将输出结果与 Hirsch Fye 部分或 DMFT 综述文章中的 Hirsch-Fye 结果进行比较，或与 Interaction Expansion CT-INT 部分的相互作用展开结果进行比较。若要重新运行某次模拟，可以通过设定输入参数 G0OMEGA_INPUT 来指定一个初始解：例如将 G0omga_output 复制为 G0_omega_input，在参数文件中设置 G0OMEGA_INPUT = G0_omega_input，然后重新运行代码。你可以通过以下脚本绘制格林函数，观察体系向反铁磁相的转变：
+完整的脚本和带注释的参数文件请参见 [DMFT-02](../dmft02#运行模拟)、[DMFT-03](../dmft03#运行模拟) 和 [DMFT-07](../dmft07#运行模拟)。
+
+### 格子
+
+三个求解器都运行在本系列教程中一直使用的、无穷配位数 $z\to\infty$ 极限下的贝特格子上，跃迁按 $t=t^*/\sqrt{z}$ 重新标度，使得半圆形态密度（半带宽 $D=2t$）可以在自洽循环中被解析求值：
 
 ```
-flavors=parms[0]['FLAVORS']
-listobs=[]   
-for f in range(0,flavors):
-    listobs.append('Green_'+str(f))
-
-ll=pyalps.load.Hdf5Loader()
-data = ll.ReadMeasurementFromFile(pyalps.getResultFiles(pattern='parm_beta_*h5'), respath='/simulation/results/G_tau', measurements=listobs, verbose=True)
-for d in pyalps.flatten(data):
-    d.x = d.x*d.props["BETA"]/float(d.props["N"])
-    d.props['label'] = r'$\beta=$'+str(d.props['BETA'])
-plt.figure()
-plt.xlabel(r'$\tau$')
-plt.ylabel(r'$G(\tau)$')
-plt.title('Hubbard model on the Bethe lattice')
-pyalps.pyplot.plot(data)
-plt.legend()
-plt.show()
+        o       o
+         \     /
+      t   \   /   t
+           \ /
+        o---o---o          o : lattice site, interaction U (on site)
+           / \              --- : bond, hopping amplitude t
+          /   \
+         /     \
+        o       o
 ```
 
-你会注意到结果的噪声相对较大。这是因为在如此高的温度下展开阶数很小，使得测量过程效率较低。你可以通过增加总运行时间（MAX_TIME）或在多个 CPU 上运行来改善统计性质。若要使用 MPI 运行，可以尝试 `mpirun -np procs dmft parameter_file`，或查阅你所使用的 MPI 安装的 man 手册。
+关于在不同格子上进行同样的比较，请参见 [DMFT-08 格子](../dmft08)。
 
-如果你想检查 DMFT 自洽过程的收敛情况，可以使用 `tutorial2b.py` 绘制不同迭代步骤的格林函数：
+### 方法选择
 
-```
-ll=pyalps.load.Hdf5Loader()
-for p in parms:
-    data = ll.ReadDMFTIterations(pyalps.getResultFiles(pattern='parm_beta_'+str(p['BETA'])+'.h5'), measurements=listobs, verbose=True)
-    grouped = pyalps.groupSets(pyalps.flatten(data), ['iteration'])
-    nd=[]
-    for group in grouped:
-        r = pyalps.DataSet()
-        r.y = np.array(group[0].y)
-        r.x = np.array([e*group[0].props['BETA']/float(group[0].props['N']) for e in group[0].x])
-        r.props = group[0].props
-        r.props['label'] = r.props['iteration']
-        nd.append( r )
-    plt.figure()
-    plt.xlabel(r'$\tau$')
-    plt.ylabel(r'$G(\tau)$')
-    plt.title(r'\beta = %.4s' %nd[0].props['BETA'])
-    pyalps.pyplot.plot(nd)
-    plt.legend()
-    plt.show()
-```
+CT-HYB、CT-INT 与 Hirsch-Fye 建立在互不相关的近似之上：CT-HYB 对杂化做展开，在强耦合下效率最高；CT-INT 对相互作用做展开，在弱到中等耦合下效率最高；Hirsch-Fye 将虚时间离散为 $N$ 个时间片，带有必须通过外推消除的系统性 $(\Delta\tau)^2$ 偏差（关于各自的细节，请参见 [DMFT-02](../dmft02)，以及 [DMFT-03](../dmft03#方法选择) 和 [DMFT-07](../dmft07#方法选择) 中的“方法选择”一节）。在 $U=3D/\sqrt{2}$ 处，这三种算法都没有明显处于对自己特别有利或不利的区域，这使得该点非常适合用来相互交叉验证：由于三个求解器不共享任何系统性偏差，凡是在三者收敛结果中都出现的特征——特别是随冷却出现的 $G(\tau)$ 反铁磁分裂——必定是物理模型与 DMFT 自洽性本身的性质，而不是某一特定蒙特卡罗算法的产物。
 
-最好通过观察自能的收敛情况来判断收敛性，因为自能对收敛更为敏感。请注意，要得到更平滑的格林函数和自能，需要更长时间的模拟。
+### 输出数据与绘图
 
-### 相互作用展开 CT-INT
-
-用 CT-INT 代码重复 Hybridization Expansion CT-HYB 部分中的计算是很有启发性的。该代码对相互作用（而非杂化）做展开。相应的参数文件与之非常相似，可以在目录 `tutorials/dmft-03-interaction` 中找到。如果你更喜欢用 python 运行模拟，可以使用 `tutorial3a.py` 和 `tutorial3b.py` 文件。
-
-### Hirsch Fye
-
-我们通过运行一个离散时间蒙特卡罗代码——[Hirsch Fye 代码](https://link.aps.org/doi/10.1103/PhysRevLett.56.2521)——将其结果与连续时间的结果进行比较。Hirsch Fye 算法在[这里](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13)有详细描述，该综述文章也提供了相应代码的开源实现。尽管已经出现了许多改进（例如可参见 Alvarez (2008) 或 [Nukala09](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.80.195111)），但这一算法已被[连续时间算法](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.76.235123)所取代。
-
-Hirsch Fye 模拟每次迭代大约需要一分钟。运行此模拟所需的参数文件可以在[本教程](../dmft07)中找到。
-
-主要参数如下：
-
-```
-SEED = 0;                    // Monte Carlo Random Number Seed
-THERMALIZATION = 10000;      // Thermalization Sweeps
-SWEEPS = 1000000;            // Total Sweeps to be computed
-MAX_TIME = 60;               // Maximum time to run the simulation
-BETA = 12.;                  // Inverse temperature
-SITES = 1;                   // This is a single site DMFT simulation, so Sites is 1
-N = 16;                      // Number of time slices (you will see that this parameter is rather small)
-NMATSUBARA = 500;            // The number of Matsubara frequencies
-U = 3;                       // Interaction energy
-t = 0.707106781187;          // hopping parameter. For the Bethe lattice considered here $W=2D=4t$
-MU = 0;                      // Chemical potential
-H = 0;                       // Magnetic field
-SYMMETRIZATION = 0;          // We are not enforcing a paramagnetic self consistency condition
-SOLVER = /opt/alps/bin/hirschfye;  // The path to the external Hirsch Fye solver
-```
-
-要启动模拟，输入：
-
-```
-dmft hirschfye.param
-```
-
-或运行 python 脚本 `tutorial7a.py`：
+与教程 02、03、07 中分别绘图不同，本教程的核心在于把三者叠加在同一张图上：
 
 ```
 import pyalps
 import numpy as np
 import matplotlib.pyplot as plt
-import pyalps.pyplot
+import pyalps.plot
 
-#prepare the input parameters 
-parms=[]
-for b in [6.,8.,10.,12.,14.,16.]: 
-    parms.append(
-        { 
-            'ANTIFERROMAGNET'     : 1,
-            'CONVERGED'           : 0.03,
-            'FLAVORS'             : 2,
-            'H'                   : 0,
-            'MAX_IT'              : 10,
-            'MAX_TIME'            : 60,
-            'MU'                  : 0,
-            'N'                   : 16,
-            'NMATSUBARA'          : 500, 
-            'OMEGA_LOOP'          : 1,
-            'SEED'                : 0, 
-            'SITES'               : 1,
-            'SOLVER'              : '/opt/alps/bin/hirschfye',
-            'SYMMETRIZATION'      : 0,
-            'TOLERANCE'           : 0.01,
-            'U'                   : 3,
-            't'                   : 0.707106781186547,
-            'SWEEPS'              : 1000000,
-            'THERMALIZATION'      : 10000,
-            'BETA'                : b,
-            'G0OMEGA_INPUT'       : 'G0_omega_input_beta_'+str(b),
-            'BASENAME'            : 'hirschfye.param'
-        }
-    )
+listobs = ['0']  # flavor 0
 
-#write the input file and run the simulation
-for p in parms:
-    input_file = pyalps.writeParameterFile('parm_beta_'+str(p['BETA']),p)
-    res = pyalps.runDMFT(input_file)
-```
+files = {
+    'CT-HYB'     : 'tutorials/dmft-02-hybridization/parm_beta_12.0.h5',
+    'CT-INT'     : 'tutorials/dmft-03-interaction/parm_beta_12.0.h5',
+    'Hirsch-Fye' : 'tutorials/dmft-07-hirschfye/parm_beta_12.0.h5',
+}
 
-程序最多运行 10 次自洽迭代。在运行程序的目录中，你会找到格林函数文件 G_tau_i、自能文件（selfenergy_i）以及频率空间下的格林函数 G_omega_i，均位于输出目录中。这些例子中的 G_tau 包含两列：自旋向上和自旋向下。$\beta$ 处的取值即为负的密度；当该值在误差棒范围之外出现差异时，体系即处于反铁磁相。你可以在 python shell 中运行以下代码，绘制不同 $\beta$ 下的格林函数，并将结果与 [Georges 等人](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13)图 11 的结果进行比较。
+alldata = []
+for solver, fname in files.items():
+    data = pyalps.loadMeasurements([fname], respath='/simulation/results/G_tau', what=listobs, verbose=False)
+    for d in pyalps.flatten(data):
+        d.x = d.x*d.props["BETA"]/float(d.props["N"])
+        d.props['label'] = solver
+        alldata.append(d)
 
-```
-flavors=parms[0]['FLAVORS']
-listobs=[]   
-for f in range(0,flavors):
-    listobs.append('Green_'+str(f))
-
-ll=pyalps.load.Hdf5Loader()
-data = ll.ReadMeasurementFromFile(pyalps.getResultFiles(pattern='parm_beta_*h5'), respath='/simulation/results/G_tau', measurements=listobs, verbose=True)
-for d in pyalps.flatten(data):
-    d.x = d.x*d.props["BETA"]/float(d.props["N"])
-    d.props['label'] = r'$\beta=$'+str(d.props['BETA'])
 plt.figure()
 plt.xlabel(r'$\tau$')
-plt.ylabel(r'$G(\tau)$')
-plt.title('Hubbard model on the Bethe lattice')
-pyalps.pyplot.plot(data)
+plt.ylabel(r'$G_{flavor=0}(\tau)$')
+plt.title('DMFT-09: Neel transition at BETA=12, solver comparison')
+pyalps.plot.plot(alldata)
 plt.legend()
 plt.show()
 ```
 
-作为一种离散时间方法，HF 会受到 $\Delta\tau$ 离散化误差的影响。请选取一组参数，并对逐渐增大的 $N$ 重复运行！另外需要注意：你正在使用一个（几乎）已收敛的输入浴函数来运行 DMFT 模拟。删除文件 G0_omega_input 后，你可以从自由解重新开始计算，并观察其收敛过程。
+由于这是对三个独立随机模拟的比较，实际得到的数值取决于各自运行的 `SEED`、`MAX_TIME` 和计算机速度，但三条曲线应在各自的误差范围内一致——不过除非像 [DMFT-07](../dmft07#小结与展望) 中建议的那样做外推，否则 Hirsch-Fye 的 `N=16` 离散化偏差相对于 CT-HYB 和 CT-INT 会是可见的。你也可以从部分收敛的解而不是从头重新运行某个求解器：将所需的 `G0omega_output` 复制为新文件名，并在重新运行之前，在参数文件（或对应的 python 字典）中通过 `G0OMEGA_INPUT` 指定它。
+
+### 小结与展望
+
+用 CT-HYB、CT-INT 和 Hirsch-Fye 求解同一个 Néel 转变，并发现三者一致，这直接验证了 DMFT-02、DMFT-03 和 DMFT-07 收敛到的是同一物理，而不是各自求解器特有的伪影。
+
+1. 将上面的合并图扩展到全部六个 $\beta$ 值（使用 `tutorial2_long.py`、`tutorial3_long.py` 和 `tutorial7_long.py`），重现完整的图 11 比较，在每个温度下都叠加三个求解器的结果。
+2. 在固定运行时间的情况下，$\beta=12$ 时三个求解器中哪一个给出的误差棒最小？在更靠近顺磁一侧的 $\beta=6$ 处，这一排序是否会改变？
+3. 在把 Hirsch-Fye 的结果纳入合并图之前，先将其外推到 $\Delta\tau\to0$（见 [DMFT-07](../dmft07#小结与展望)）。外推后的曲线是否明显更接近 CT-HYB 和 CT-INT？
+4. [DMFT-06](../dmft06) 做了类似的跨求解器比较，但是在顺磁金属相中，并与 [Georges et al. (1996)](https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.68.13) 图 15 中数值精确的精确对角化／Hirsch-Fye 基准做比较。比较这两种情形：求解器之间的一致性，在教程 06 的顺磁金属中更容易达到，还是在本教程所研究的反铁磁相中更容易达到？


### PR DESCRIPTION
## Summary
- DMFT-08 (Lattices) was missing physics motivation, a model/parameter overview, lattice diagrams for the four bundled DOS lattices (square, cubic, hexagonal, Bethe), a method-choice discussion (`DOSFILE` vs `TWODBS`), and an output/plots section. The real upstream `tutorial8a.py`/`tutorial8b.py` scripts already contained plotting code that the page had cut off — restored it and added the surrounding narrative.
- DMFT-09 (Néel Transition) referenced tutorial scripts and a parameter directory that don't exist upstream (`tutorial2a.py`, `tutorial3a.py`, `tutorial7a.py`, a `beta_14_U3_tsqrt2` directory), and used an outdated `pyalps.pyplot`/`Hdf5Loader` API inconsistent with the already-updated DMFT-02/03/07 pages. Rewrote it around the real `tutorial2.py`/`tutorial3.py`/`tutorial7.py` scripts and parameter values, and added a combined plot overlaying all three solvers' G(τ) on one figure — the actual point of a "merged" tutorial, which was previously missing.
- Extended/fixed in `en/`, `ja/`, and `zh-cn/`. All cross-reference anchors (including in-page `#heading` fragments) were checked against the actual built HTML headings in each language, not just assumed from the English slug.

## Test plan
- [x] `hugo --gc --minify` builds all three language trees (en/ja/zh-cn) with no new errors or warnings
- [x] Verified in the built HTML that cross-reference links, including in-page anchors, resolve to real headings in each language
- [x] Verified the lattice ASCII diagrams render correctly (the hexagonal one was caught and corrected mid-review to show actual hexagonal rings instead of a bowtie shape)
