### PR TITLE
Document per-application support for custom measurements, translate cn/ja

### DIFF
--- a/content/en/documentation/intro/measuredef.md
+++ b/content/en/documentation/intro/measuredef.md
@@ -7,28 +7,50 @@ weight: 6
 
 ## Defining your custom measurements
 
-In case the default measurements performed by your favorite ALPS code do not suffice for your problem, you can define your custom measurements in the parameter file. The general syntax is as follows:
+If the default measurements performed by your ALPS application do not cover what you need, you can define custom measurements directly in the parameter file. The general syntax is as follows:
 
     MEASURE_LOCAL[Name]=Op
     MEASURE_AVERAGE[Name]=Op
 
-Here "Name" is the name under which your measurements appear in the xml output, and "Op" is the measurement operator, which must be defined in the `models.xml` file. MEASURE_AVERAGE measures the quantum mechanical and (for finite temperature simulations) thermodynamic expectation value of the operator Op. MEASURE_LOCAL measures the expectation values of the operator Op for each site of the lattice. The operator must be local, i.e., it can only have site terms.
+Here `Name` is the name under which the measurement appears in the XML output, and `Op` is a site or bond operator, which must already be defined for the model — either a built-in operator from the model library or one you defined yourself (see [Quantum Operators](../modeldef/operators)). `MEASURE_AVERAGE` measures the quantum-mechanical, and (for finite-temperature simulations) thermodynamic, expectation value of `Op`. `MEASURE_LOCAL` measures the expectation value of `Op` at each site of the lattice; `Op` must therefore be local, i.e. it can only have site terms, not bond terms.
 
     MEASURE_CORRELATIONS[Name]="Op1:Op2"
-    MEASURE_CORRELATIONS[Name]=Op    
+    MEASURE_CORRELATIONS[Name]=Op
 
-MEASURE_CORRELATIONS measures the correlations of the operators Op1 and Op2 for all inequivalent pairs of sites of the lattice. The second form above, MEASURE_CORRELATIONS[Name]=Op is equivalent to MEASURE_CORRELATIONS[Name]="Op:Op". At present, only two-site correlation functions can be computed. That is, both Op1 and Op2 must be site operators.
+`MEASURE_CORRELATIONS` measures the correlations of the operators `Op1` and `Op2` for all inequivalent pairs of sites of the lattice. The second form above, `MEASURE_CORRELATIONS[Name]=Op`, is equivalent to `MEASURE_CORRELATIONS[Name]="Op:Op"`. At present, only two-site correlation functions can be computed, so both `Op1` and `Op2` must be site operators.
 
     MEASURE_STRUCTURE_FACTOR[Name]=Op
 
-This measures the structure factor for the operator Op using the momentum eigenstates for the simulation lattice.
+This measures the structure factor for the operator `Op`, i.e. the lattice Fourier transform of the corresponding correlation function, evaluated at the momentum eigenstates of the simulation lattice.
 
-Notice that not all ALPS codes support all the above statements. Several codes have additional facilities for defining measurements. Consult the tutorial pages for your favorite code.
+## Which ALPS applications support this
+
+The `MEASURE_LOCAL`/`MEASURE_AVERAGE`/`MEASURE_CORRELATIONS`/`MEASURE_STRUCTURE_FACTOR` syntax above is not interpreted by the model or lattice XML machinery itself — it is optional functionality that each simulation code has to wire in separately, and in practice only a subset of ALPS applications do:
+
+| Application | Support |
+| :---------- | :------ |
+| `loop` (loop/directed-loop algorithm) | Full support |
+| `worm` ([Worm Algorithm](../../methods/qmc/worm)) | Full support |
+| `sse`, `sse2`, `sse4` ([Stochastic Series Expansion](../../methods/qmc/sse)) | Full support |
+| `dwa` (directed worm algorithm) | Full support |
+| `fulldiag` (full diagonalization) | Full support |
+| `dmrg` ([legacy single-block DMRG](../../methods/dmrg/dmrg)) | Full support |
+| `sparsediag` ([sparse/Lanczos diagonalization](../../methods/ed/sparsediag)) | Not supported — only the observables built into the model itself (energies, quantum numbers) are available |
+| `qwl` (quantum Wang-Landau) | Not supported — has its own dedicated `MEASURE_MAGNETIC_PROPERTIES` flag instead |
+| `checksign` | Not supported |
+| `mps_optim`/`mps_meas` (matrix-product-state DMRG) | Has its own, independently implemented and richer syntax — see below |
+
+For the codes marked "full support" above (`loop`, `worm`, `sse`/`sse2`/`sse4`, `dwa`, `fulldiag`, `dmrg`), a custom `Name` that collides with one of the code's built-in observable names (e.g. `Local Density`, `Spin Correlations`) is silently skipped in favor of the built-in one, with a note to standard error — so give your custom measurements distinctive names.
+
+The matrix-product-state DMRG code (`mps_optim`/`mps_meas`) does not use the mechanism described on this page at all; it has its own reimplementation that accepts `MEASURE_LOCAL`, `MEASURE_AVERAGE`, and `MEASURE_CORRELATIONS` with the same meaning as above, plus several extensions with no equivalent elsewhere in ALPS: `MEASURE_HALF_CORRELATIONS` (like `MEASURE_CORRELATIONS`, but without exchanging the order of operators), `MEASURE_LOCAL_AT` (apply a sequence of operators to an explicit, arbitrary tuple of sites), and boolean flags such as `MEASURE[EnergyVariance]`, `MEASURE[Entropy]`, and `MEASURE[Renyi2]`.
+
+Since support varies so much from code to code, always check the parameter reference or tutorial for the specific application you are using before relying on any of these statements.
 
 ## Further tricks and workarounds
 
 Measuring off-diagonal quantities in QMC codes is in general non-trivial and is hard to implement in a generic fashion. If your favorite QMC program refuses to perform your favorite measurement, you may need to modify the source code.
-In certain cases, however several tricks can be used. One useful trick is to enlarge the site basis of your model. Consider the following example: Using the worm code to simulate the Bose Hubbard model on an inhomogeneous lattice, measure the second moment of local density distribution $\langle n_i^2\rangle$. Since the worm code does not work in the site basis, it will not perform measurements for such an operator. One possible solution would be to patch the site basis "boson" which is used by the Bose Hubbard hamiltonian:
+
+In certain cases, however, several tricks can be used. One useful trick is to enlarge the site basis of your model. Consider the following example: using the worm code to simulate the Bose-Hubbard model on an inhomogeneous lattice, we want to measure the second moment of the local density distribution $\langle n_i^2\rangle$. Since the worm code does not work in the site basis, it will not perform measurements for such an operator directly. One possible solution is to patch the `boson` site basis used by the Bose-Hubbard Hamiltonian, adding an `n2` operator for the squared density:
 
     <SITEBASIS name="boson">
     <PARAMETER name="Nmax" default="infinity"/>
@@ -40,14 +62,14 @@ In certain cases, however several tricks can be used. One useful trick is to enl
         <CHANGE quantumnumber="N" change="-1"/>
     </OPERATOR>
     <OPERATOR name="n" matrixelement="N"/>
-    <OPERATOR name="n2" matrixelement="N*N"/>   <--!  added -->
-    </SITEBASIS> 
- 
- With this patch, one may define the corresponding measurements in a usual fashion, e.g.
- 
+    <OPERATOR name="n2" matrixelement="N*N"/>   <!-- added -->
+    </SITEBASIS>
+
+With this patch, one can define the corresponding measurements in the usual fashion, e.g.
+
     MEASURE_LOCAL[Local density squared]="n2"
     MEASURE_CORRELATIONS[Density squared, correlations]="n2:n2"
 
+---
 
-
-
+For how the operators used above are defined, see [Quantum Operators](../modeldef/operators). For an overview of model definitions in general, see [ALPS Model Definitions](../modeldef). For the other ALPS documentation sections, see the [General Introduction](..).

--- a/content/ja/documentation/intro/measuredef.md
+++ b/content/ja/documentation/intro/measuredef.md
@@ -1,34 +1,56 @@
 
 ---
-title: ALPS Custom Measurement
+title: ALPS カスタム測定
 toc: true
 weight: 6
 ---
 
-## Defining your custom measurements
+## 独自の測定を定義する
 
-In case the default measurements performed by your favorite ALPS code do not suffice for your problem, you can define your custom measurements in the parameter file. The general syntax is as follows:
+お使いの ALPS アプリケーションが標準で行う測定だけでは不十分な場合、パラメータファイル内で独自の測定を直接定義できます。一般的な構文は次のとおりです。
 
     MEASURE_LOCAL[Name]=Op
     MEASURE_AVERAGE[Name]=Op
 
-Here "Name" is the name under which your measurements appear in the xml output, and "Op" is the measurement operator, which must be defined in the `models.xml` file. MEASURE_AVERAGE measures the quantum mechanical and (for finite temperature simulations) thermodynamic expectation value of the operator Op. MEASURE_LOCAL measures the expectation values of the operator Op for each site of the lattice. The operator must be local, i.e., it can only have site terms.
+ここで `Name` は、その測定が XML 出力中に現れる際の名前であり、`Op` はサイト演算子またはボンド演算子で、あらかじめモデル側で定義されている必要があります —— モデルライブラリに組み込まれている演算子でも、自分で定義した演算子でも構いません（[量子演算子](../modeldef/operators) を参照）。`MEASURE_AVERAGE` は `Op` の量子力学的期待値（有限温度シミュレーションの場合は熱力学的期待値も含む）を測定します。`MEASURE_LOCAL` は格子の各サイトにおける `Op` の期待値を測定します。したがって `Op` は局所的な演算子、すなわちサイト項のみを持ちボンド項を持たない演算子でなければなりません。
 
     MEASURE_CORRELATIONS[Name]="Op1:Op2"
-    MEASURE_CORRELATIONS[Name]=Op    
+    MEASURE_CORRELATIONS[Name]=Op
 
-MEASURE_CORRELATIONS measures the correlations of the operators Op1 and Op2 for all inequivalent pairs of sites of the lattice. The second form above, MEASURE_CORRELATIONS[Name]=Op is equivalent to MEASURE_CORRELATIONS[Name]="Op:Op". At present, only two-site correlation functions can be computed. That is, both Op1 and Op2 must be site operators.
+`MEASURE_CORRELATIONS` は、格子上のすべての非等価なサイト対について、演算子 `Op1` と `Op2` の相関を測定します。上の 2 番目の形式 `MEASURE_CORRELATIONS[Name]=Op` は `MEASURE_CORRELATIONS[Name]="Op:Op"` と等価です。現時点では 2 点相関関数のみ計算できるため、`Op1` と `Op2` はどちらもサイト演算子でなければなりません。
 
     MEASURE_STRUCTURE_FACTOR[Name]=Op
 
-This measures the structure factor for the operator Op using the momentum eigenstates for the simulation lattice.
+これは演算子 `Op` の構造因子、すなわち対応する相関関数を、シミュレーション格子の運動量固有状態において評価した格子フーリエ変換を測定します。
 
-Notice that not all ALPS codes support all the above statements. Several codes have additional facilities for defining measurements. Consult the tutorial pages for your favorite code.
+## どの ALPS アプリケーションがこれをサポートしているか
 
-## Further tricks and workarounds
+上記の `MEASURE_LOCAL`/`MEASURE_AVERAGE`/`MEASURE_CORRELATIONS`/`MEASURE_STRUCTURE_FACTOR` という構文は、モデルや格子の XML 処理系そのものが解釈しているわけではありません —— これは各シミュレーションコードが個別に組み込む必要のあるオプション機能であり、実際にサポートしているのは ALPS アプリケーションの一部にすぎません。
 
-Measuring off-diagonal quantities in QMC codes is in general non-trivial and is hard to implement in a generic fashion. If your favorite QMC program refuses to perform your favorite measurement, you may need to modify the source code.
-In certain cases, however several tricks can be used. One useful trick is to enlarge the site basis of your model. Consider the following example: Using the worm code to simulate the Bose Hubbard model on an inhomogeneous lattice, measure the second moment of local density distribution $\langle n_i^2\rangle$. Since the worm code does not work in the site basis, it will not perform measurements for such an operator. One possible solution would be to patch the site basis "boson" which is used by the Bose Hubbard hamiltonian:
+| アプリケーション | サポート状況 |
+| :---------- | :------ |
+| `loop`（ループ / ディレクテッドループアルゴリズム） | 完全サポート |
+| `worm`（[ワームアルゴリズム](../../methods/qmc/worm)） | 完全サポート |
+| `sse`、`sse2`、`sse4`（[確率級数展開](../../methods/qmc/sse)） | 完全サポート |
+| `dwa`（ディレクテッドワームアルゴリズム） | 完全サポート |
+| `fulldiag`（完全対角化） | 完全サポート |
+| `dmrg`（[従来の単一ブロック DMRG](../../methods/dmrg/dmrg)） | 完全サポート |
+| `sparsediag`（[疎行列 / Lanczos 対角化](../../methods/ed/sparsediag)） | 非サポート —— モデル自体に組み込まれた物理量（エネルギー、量子数）のみ取得可能 |
+| `qwl`（量子 Wang-Landau 法） | 非サポート —— 専用の `MEASURE_MAGNETIC_PROPERTIES` フラグを持つ |
+| `checksign` | 非サポート |
+| `mps_optim`/`mps_meas`（行列積状態 DMRG） | 独自に実装された、より豊富な構文を持つ —— 詳細は後述 |
+
+上表で「完全サポート」と記載されているコード（`loop`、`worm`、`sse`/`sse2`/`sse4`、`dwa`、`fulldiag`、`dmrg`）については、指定した `Name` がそのコードに組み込みの観測量名（例: `Local Density`、`Spin Correlations`）と衝突する場合、独自の測定は黙って無視され、組み込みの測定が優先されます（標準エラー出力に注意メッセージが出力されます）。そのため、独自の測定には他と重複しない名前を付けてください。
+
+行列積状態 DMRG コード（`mps_optim`/`mps_meas`）は、このページで説明した仕組みを一切使用していません。代わりに独自に実装されたバージョンを持ち、上記と同じ意味で `MEASURE_LOCAL`、`MEASURE_AVERAGE`、`MEASURE_CORRELATIONS` を受け付けるほか、ALPS の他のどこにも存在しないいくつかの拡張機能を備えています: `MEASURE_HALF_CORRELATIONS`（`MEASURE_CORRELATIONS` と同様ですが、演算子の順序を入れ替えません）、`MEASURE_LOCAL_AT`（明示的に指定した任意のサイトの組に対して演算子の列を作用させます）、そして `MEASURE[EnergyVariance]`、`MEASURE[Entropy]`、`MEASURE[Renyi2]` のような真偽値フラグです。
+
+コードごとにサポート状況が大きく異なるため、これらの構文に頼る前には、必ず使用するアプリケーションのパラメータリファレンスやチュートリアルを確認してください。
+
+## その他のテクニックと回避策
+
+QMC コードで非対角量を測定することは一般に自明ではなく、汎用的な方法で実装するのは困難です。お使いの QMC プログラムが希望する測定を拒否する場合、ソースコードを修正する必要があるかもしれません。
+
+しかし、場合によってはいくつかのテクニックを使うことができます。よく使われるテクニックの一つは、モデルのサイト基底を拡張することです。例を挙げましょう。不均一格子上で Bose-Hubbard モデルを worm コードでシミュレートしており、局所密度分布の 2 次モーメント $\langle n_i^2\rangle$ を測定したいとします。worm コードはサイト基底上で直接動作しないため、このような演算子に対する測定をそのままでは行えません。一つの解決策は、Bose-Hubbard ハミルトニアンが用いる `boson` サイト基底にパッチを当て、密度の二乗を表す演算子 `n2` を追加することです。
 
     <SITEBASIS name="boson">
     <PARAMETER name="Nmax" default="infinity"/>
@@ -40,14 +62,14 @@ In certain cases, however several tricks can be used. One useful trick is to enl
         <CHANGE quantumnumber="N" change="-1"/>
     </OPERATOR>
     <OPERATOR name="n" matrixelement="N"/>
-    <OPERATOR name="n2" matrixelement="N*N"/>   <--!  added -->
-    </SITEBASIS> 
- 
- With this patch, one may define the corresponding measurements in a usual fashion, e.g.
- 
+    <OPERATOR name="n2" matrixelement="N*N"/>   <!-- added -->
+    </SITEBASIS>
+
+このパッチを適用すれば、通常どおり対応する測定を定義できます。例えば:
+
     MEASURE_LOCAL[Local density squared]="n2"
     MEASURE_CORRELATIONS[Density squared, correlations]="n2:n2"
 
+---
 
-
-
+上で使用した演算子の定義方法については [量子演算子](../modeldef/operators) を参照してください。モデル定義全般の概要については [ALPS モデル定義](../modeldef) を参照してください。ALPS ドキュメントの他のセクションについては [総合案内](..) を参照してください。

--- a/content/zh-cn/documentation/intro/measuredef.md
+++ b/content/zh-cn/documentation/intro/measuredef.md
@@ -1,34 +1,56 @@
 
 ---
-title: ALPS Custom Measurement
+title: ALPS 自定义测量
 toc: true
 weight: 6
 ---
 
-## Defining your custom measurements
+## 定义自定义测量
 
-In case the default measurements performed by your favorite ALPS code do not suffice for your problem, you can define your custom measurements in the parameter file. The general syntax is as follows:
+如果你所用的 ALPS 应用程序自带的默认测量无法满足需求，可以直接在参数文件中定义自定义测量。其一般语法如下：
 
     MEASURE_LOCAL[Name]=Op
     MEASURE_AVERAGE[Name]=Op
 
-Here "Name" is the name under which your measurements appear in the xml output, and "Op" is the measurement operator, which must be defined in the `models.xml` file. MEASURE_AVERAGE measures the quantum mechanical and (for finite temperature simulations) thermodynamic expectation value of the operator Op. MEASURE_LOCAL measures the expectation values of the operator Op for each site of the lattice. The operator must be local, i.e., it can only have site terms.
+这里 `Name` 是该测量在 XML 输出中出现时使用的名称，`Op` 是一个格点算符或键算符，它必须已经在模型中定义 —— 既可以是模型库中内置的算符，也可以是你自己定义的算符（参见[量子算符](../modeldef/operators)）。`MEASURE_AVERAGE` 测量 `Op` 的量子力学期望值，对于有限温度模拟还包括热力学期望值。`MEASURE_LOCAL` 测量 `Op` 在格子每个格点上的期望值；因此 `Op` 必须是局域的，即只能含有格点项，不能含有键项。
 
     MEASURE_CORRELATIONS[Name]="Op1:Op2"
-    MEASURE_CORRELATIONS[Name]=Op    
+    MEASURE_CORRELATIONS[Name]=Op
 
-MEASURE_CORRELATIONS measures the correlations of the operators Op1 and Op2 for all inequivalent pairs of sites of the lattice. The second form above, MEASURE_CORRELATIONS[Name]=Op is equivalent to MEASURE_CORRELATIONS[Name]="Op:Op". At present, only two-site correlation functions can be computed. That is, both Op1 and Op2 must be site operators.
+`MEASURE_CORRELATIONS` 测量算符 `Op1` 和 `Op2` 在格子上所有不等价格点对之间的关联。上面第二种写法 `MEASURE_CORRELATIONS[Name]=Op` 等价于 `MEASURE_CORRELATIONS[Name]="Op:Op"`。目前只能计算两点关联函数，因此 `Op1` 和 `Op2` 都必须是格点算符。
 
     MEASURE_STRUCTURE_FACTOR[Name]=Op
 
-This measures the structure factor for the operator Op using the momentum eigenstates for the simulation lattice.
+这将测量算符 `Op` 的结构因子，即相应关联函数在模拟格子的动量本征态上求值得到的格子傅里叶变换。
 
-Notice that not all ALPS codes support all the above statements. Several codes have additional facilities for defining measurements. Consult the tutorial pages for your favorite code.
+## 哪些 ALPS 应用程序支持这一机制
 
-## Further tricks and workarounds
+上述 `MEASURE_LOCAL`/`MEASURE_AVERAGE`/`MEASURE_CORRELATIONS`/`MEASURE_STRUCTURE_FACTOR` 语法并不是由模型或格子的 XML 解析机制本身负责解释的 —— 它是一项可选功能，需要每个模拟程序单独接入；实际上只有部分 ALPS 应用程序支持它：
 
-Measuring off-diagonal quantities in QMC codes is in general non-trivial and is hard to implement in a generic fashion. If your favorite QMC program refuses to perform your favorite measurement, you may need to modify the source code.
-In certain cases, however several tricks can be used. One useful trick is to enlarge the site basis of your model. Consider the following example: Using the worm code to simulate the Bose Hubbard model on an inhomogeneous lattice, measure the second moment of local density distribution $\langle n_i^2\rangle$. Since the worm code does not work in the site basis, it will not perform measurements for such an operator. One possible solution would be to patch the site basis "boson" which is used by the Bose Hubbard hamiltonian:
+| 应用程序 | 支持情况 |
+| :---------- | :------ |
+| `loop`（loop / 有向环算法） | 完全支持 |
+| `worm`（[Worm 算法](../../methods/qmc/worm)） | 完全支持 |
+| `sse`、`sse2`、`sse4`（[随机级数展开](../../methods/qmc/sse)） | 完全支持 |
+| `dwa`（有向蠕虫算法） | 完全支持 |
+| `fulldiag`（完全对角化） | 完全支持 |
+| `dmrg`（[传统的单块 DMRG](../../methods/dmrg/dmrg)） | 完全支持 |
+| `sparsediag`（[稀疏 / Lanczos 对角化](../../methods/ed/sparsediag)） | 不支持 —— 只能得到模型本身内置的可观测量（能量、量子数） |
+| `qwl`（量子 Wang-Landau） | 不支持 —— 它有自己专门的 `MEASURE_MAGNETIC_PROPERTIES` 开关 |
+| `checksign` | 不支持 |
+| `mps_optim`/`mps_meas`（矩阵乘积态 DMRG） | 有自己独立实现的、更丰富的语法 —— 见下文 |
+
+对于上表中标注为“完全支持”的程序（`loop`、`worm`、`sse`/`sse2`/`sse4`、`dwa`、`fulldiag`、`dmrg`），如果自定义的 `Name` 与程序内置的可观测量名称（例如 `Local Density`、`Spin Correlations`）冲突，该自定义测量会被静默跳过，而使用内置的那个，同时会在标准错误输出中给出提示 —— 因此请为自定义测量取一个不会重名的名字。
+
+矩阵乘积态 DMRG 程序（`mps_optim`/`mps_meas`）完全没有使用本页描述的这套机制；它有自己独立实现的版本，同样接受含义相同的 `MEASURE_LOCAL`、`MEASURE_AVERAGE` 和 `MEASURE_CORRELATIONS`，此外还有若干 ALPS 中其他程序都没有的扩展：`MEASURE_HALF_CORRELATIONS`（与 `MEASURE_CORRELATIONS` 类似，但不交换算符的顺序）、`MEASURE_LOCAL_AT`（将一串算符作用在一组显式指定的任意格点上），以及若干布尔开关，如 `MEASURE[EnergyVariance]`、`MEASURE[Entropy]` 和 `MEASURE[Renyi2]`。
+
+由于不同程序的支持情况差异很大，在使用这些语句之前，请务必查阅你所使用的具体应用程序的参数参考或教程。
+
+## 更多技巧与变通方法
+
+在 QMC 程序中测量非对角量通常并不容易，也很难以通用的方式实现。如果你常用的 QMC 程序无法完成你想要的测量，你可能需要修改源代码。
+
+不过在某些情况下，可以使用一些技巧。一个常用的技巧是扩大模型的格点基。举例来说：使用 worm 程序在非均匀格子上模拟 Bose-Hubbard 模型，我们希望测量局域粒子数分布的二阶矩 $\langle n_i^2\rangle$。由于 worm 程序并不直接在格点基下工作，它无法直接对这样的算符进行测量。一种可行的解决办法是修改 Bose-Hubbard 哈密顿量所使用的 `boson` 格点基，为其添加一个表示密度平方的算符 `n2`：
 
     <SITEBASIS name="boson">
     <PARAMETER name="Nmax" default="infinity"/>
@@ -40,14 +62,14 @@ In certain cases, however several tricks can be used. One useful trick is to enl
         <CHANGE quantumnumber="N" change="-1"/>
     </OPERATOR>
     <OPERATOR name="n" matrixelement="N"/>
-    <OPERATOR name="n2" matrixelement="N*N"/>   <--!  added -->
-    </SITEBASIS> 
- 
- With this patch, one may define the corresponding measurements in a usual fashion, e.g.
- 
+    <OPERATOR name="n2" matrixelement="N*N"/>   <!-- added -->
+    </SITEBASIS>
+
+有了这个补丁之后，就可以按通常方式定义相应的测量，例如：
+
     MEASURE_LOCAL[Local density squared]="n2"
     MEASURE_CORRELATIONS[Density squared, correlations]="n2:n2"
 
+---
 
-
-
+关于上文中使用的算符的定义方式，参见[量子算符](../modeldef/operators)。关于模型定义的总体介绍，参见 [ALPS 模型定义](../modeldef)。关于 ALPS 文档的其他章节，参见[总体介绍](..)。


### PR DESCRIPTION
## Summary
- Reworked the [ALPS Custom Measurement](https://alps.comp-phys.org/documentation/intro/measuredef/) page: fixed grammar/quoting inconsistencies, corrected a malformed XML comment (`<--! -->` → `<!-- -->`) in the boson-basis patch example, and added cross-links to Quantum Operators/Model Definitions.
- Added a new "Which ALPS applications support this" section documenting, per application, whether the generic `MEASURE_LOCAL`/`MEASURE_AVERAGE`/`MEASURE_CORRELATIONS`/`MEASURE_STRUCTURE_FACTOR` syntax is actually implemented — determined by reading the ALPS source (`alps::MeasurementOperators` and each application's use of it):
  - Shared implementation: `loop`, `worm`, `sse`/`sse2`/`sse4`, `dwa`, `fulldiag`, legacy `dmrg`
  - Not supported at all: `sparsediag`, `qwl`, `checksign`
  - Independent, richer reimplementation: the MPS-based DMRG code (`mps_optim`/`mps_meas`), including extensions (`MEASURE_HALF_CORRELATIONS`, `MEASURE_LOCAL_AT`, `MEASURE[EnergyVariance]`, etc.) with no equivalent elsewhere in ALPS
  - Also notes a silent-name-collision gotcha for the shared-implementation codes
- Fully translated the `zh-cn` and `ja` copies of the page to match (prose translated; code blocks, XML, and parameter/operator names left verbatim).

## Test plan
- [x] `hugo --gc` builds cleanly across all three language trees
- [x] Verified all internal relative links resolve to the correct generated URLs (checked `public/` output)
- [x] Verified `zh-cn`/`ja` content is fully translated and structurally in sync with `en`
