### PR TITLE
Translate ALPS Model Definitions section into zh-cn and ja

### DIFF
--- a/content/ja/documentation/intro/modeldef/_index.md
+++ b/content/ja/documentation/intro/modeldef/_index.md
@@ -1,28 +1,28 @@
 
 ---
-title: ALPS Model Definitions
+title: ALPS モデル定義
 toc: true
 weight: 5
 ---
 
-As part of the ALPS project we need to describe quantum lattice models in a common XML format, independent of the lattice they run on (see [Lattice Definitions](../latticehowtos) for that half of an ALPS input file). This section builds that format up in stages: from the model library file and its overall `<MODEL>`/`<SITEBASIS>`/`<BASIS>`/`<HAMILTONIAN>` structure, through the basis of a single site and of the full lattice, to the quantum operators and Hamiltonian terms built from them.
+ALPS プロジェクトの一部として、量子格子モデルを、それが乗る格子とは独立に共通の XML 形式で記述する必要があります（格子側については [格子定義](../latticehowtos) を参照）。本セクションでは、この形式を段階的に構築していきます。モデルライブラリファイルとその全体構造である `<MODEL>`/`<SITEBASIS>`/`<BASIS>`/`<HAMILTONIAN>` から始め、単一サイトの基底、格子全体の基底を経て、そこから組み立てられる量子演算子とハミルトニアン項へと進みます。
 
-## [Introduction](intro)
+## [はじめに](intro)
 
-An overview of the ALPS model library file (`lib/xml/models.xml`), the built-in models it provides (spin, boson/fermion Hubbard, t-J, Kondo lattice, and more) with a glossary of their parameters and citations to the original papers, and the four-part `<MODEL>`/`<SITEBASIS>`/`<BASIS>`/`<HAMILTONIAN>` structure used to define a custom model.
+ALPS モデルライブラリファイル（`lib/xml/models.xml`）の概要、そこに含まれる組み込みモデル（スピン、ボソン/フェルミオン・ハバードモデル、t-J モデル、近藤格子モデルなど）についてのパラメータ一覧と元論文の引用、およびカスタムモデルの定義に使う `<MODEL>`/`<SITEBASIS>`/`<BASIS>`/`<HAMILTONIAN>` の 4 部構成について説明します。
 
-## [Site Basis](sitebasis)
+## [サイト基底](sitebasis)
 
-How to describe the Hilbert space of a single site with one or more `<QUANTUMNUMBER>` elements, including fermionic vs. bosonic quantum numbers, parametrized ranges and defaults, and models such as the t-J model where several equivalent choices of quantum numbers are possible.
+1 つ以上の `<QUANTUMNUMBER>` 要素を用いて単一サイトのヒルベルト空間を記述する方法。フェルミオン的量子数とボソン的量子数の違い、パラメータ化された範囲とデフォルト値、そして t-J モデルのように複数の等価な量子数の選び方が存在するモデルについて扱います。
 
-## [Lattice Basis](latticebasis)
+## [格子基底](latticebasis)
 
-How to combine single-site bases into the basis of the whole lattice with `<BASIS>`, covering lattices with more than one site per unit cell (including the `#` wildcard shortcut for per-type parameters), and how to restrict the basis with a `<CONSTRAINT>` on a summed quantum number (e.g. total `Sz`).
+`<BASIS>` を用いて単一サイトの基底を格子全体の基底へと組み合わせる方法。単位胞に複数のサイトを持つ格子（タイプごとのパラメータを表す `#` ワイルドカードの省略記法を含む）、および `<CONSTRAINT>` を用いてサイトについて総和した量子数（例えば全 `Sz`）で基底を制限する方法を扱います。
 
-## [Quantum Operators](operators)
+## [量子演算子](operators)
 
-How to define the operators the Hamiltonian is built from: simple site operators with an explicit matrix element and quantum-number `<CHANGE>` (e.g. `Splus`, `bdag`, `cdag_up`), complex `<SITEOPERATOR>`s built from simpler ones (e.g. `Sx`), and two-site `<BONDOPERATOR>`s (e.g. `exchange`, `fermion_hop`).
+ハミルトニアンを組み立てるための演算子の定義方法。明示的な行列要素と量子数の `<CHANGE>` を持つ単純なサイト演算子（`Splus`、`bdag`、`cdag_up` など）、より単純な演算子から組み立てられる複合的な `<SITEOPERATOR>`（`Sx` など）、および 2 サイトにまたがる `<BONDOPERATOR>`（`exchange`、`fermion_hop` など）を扱います。
 
-## [Hamiltonian Descriptions](hamiltonian)
+## [ハミルトニアンの記述](hamiltonian)
 
-How to assemble a `<HAMILTONIAN>` from `<PARAMETER>` defaults, a `<BASIS>` reference, and `<SITETERM>`/`<BONDTERM>` elements — including type-dependent couplings, either via an explicit `type` attribute or the `#` wildcard.
+`<PARAMETER>` のデフォルト値、`<BASIS>` への参照、`<SITETERM>`/`<BONDTERM>` 要素から `<HAMILTONIAN>` を組み立てる方法。明示的な `type` 属性または `#` ワイルドカードによる、タイプに依存した結合の指定方法を含みます。

--- a/content/ja/documentation/intro/modeldef/hamiltonian.md
+++ b/content/ja/documentation/intro/modeldef/hamiltonian.md
@@ -1,11 +1,11 @@
 
 ---
-title: Hamiltonian Descriptions
+title: ハミルトニアンの記述
 toc: true
 weight: 5
 ---
 
-With these elements we can now describe the Hamiltonian of a model. A simple hardcore boson model could be:
+これらの要素がそろえば、モデルのハミルトニアンを記述できるようになります。単純なハードコアボソンモデルは次のように書けます。
 
     <HAMILTONIAN name="hardcore boson">
     <PARAMETER name="mu" default="0"/>
@@ -23,13 +23,13 @@ With these elements we can now describe the Hamiltonian of a model. A simple har
     </BONDTERM>
     </HAMILTONIAN>
 
-First, default values can be specified for parameters such as coupling constants by using `<PARAMETER>` elements. Next, one `<BASIS>` element specifies the basis used for the model, either fully specified inline or by a reference (using the `ref` attribute).
+まず、`<PARAMETER>` 要素を使って、結合定数などのパラメータにデフォルト値を指定できます。次に、1 つの `<BASIS>` 要素がそのモデルで使われる基底を指定します。基底はその場で完全に指定することも、ref 属性による参照として指定することもできます。
 
-The terms of the Hamiltonian are next specified by site terms, associated with the sites of the lattice, and bond terms, associated with the bonds. Each of the `<SITETERM>` and `<BONDTERM>` elements can optionally take a type attribute, specifying which type of site (or bond) the term applies to — the same types specified in the lattice description. Omitting the type attribute applies the term to all sites or bonds for which no other term is explicitly specified.
+続いてハミルトニアンの各項を、格子のサイトに対応するサイト項と、ボンドに対応するボンド項によって指定します。`<SITETERM>` および `<BONDTERM>` の各要素は、オプションで type 属性を取ることができ、その項がどのタイプのサイト（またはボンド）に適用されるかを指定します——これは格子の記述で指定されているのと同じタイプです。type 属性を省略すると、その項は他に明示的に項が指定されていないすべてのサイトまたはボンドに適用されます。
 
-The `<SITETERM>` elements contain terms of the Hamiltonian associated with a single site. In the above example the term `mu` refers to the parameter `mu` while the term `n` refers to the operator `n` described in [Quantum Operators](../operators). In the `<BONDTERM>` elements, the operators must refer to two different sites; this is done by adding the site index in parentheses after the operator, e.g. as in `n(i)` to act on site `i`. The source and target attributes name the variables used to refer to the two sites (`i` and `j` in the example).
+`<SITETERM>` 要素には、単一サイトに関連するハミルトニアンの項が含まれます。上の例では、項 `mu` はパラメータ `mu` を指し、項 `n` は[量子演算子](../operators)で説明した演算子 `n` を指します。`<BONDTERM>` 要素では、演算子は 2 つの異なるサイトを参照しなければなりません。これは演算子の後に括弧でサイトのインデックスを付けることで行い、例えば `n(i)` はサイト `i` に作用することを表します。source 属性と target 属性は、2 つのサイトを指すために使う変数名（この例では `i` と `j`）を指定します。
 
-To simplify writing Hamiltonians, previously defined site and bond operators can be reused instead of writing out matrix elements again. For a transverse field spin model we can use the `Sx` and `exchange` operators defined in [Quantum Operators](../operators):
+ハミルトニアンの記述を簡単にするため、行列要素を改めて書き出す代わりに、以前定義したサイト演算子やボンド演算子を再利用できます。横磁場スピンモデルでは、[量子演算子](../operators)で定義した `Sx` と `exchange` の演算子を使うことができます。
 
     <HAMILTONIAN name="spin">
     <PARAMETER name="J" default="1"/>
@@ -44,7 +44,7 @@ To simplify writing Hamiltonians, previously defined site and bond operators can
     </BONDTERM>
     </HAMILTONIAN>
 
-Site-type dependent coupling terms can either be specified as in the first example, giving a type attribute restricting the applicability of a site or bond term, or by using the `#` wildcard character in the name of coupling constants, which will be replaced by the type of the site or bond as in:
+サイト（またはボンド）のタイプに依存する結合項は、最初の例のように type 属性でサイト項・ボンド項の適用範囲を制限して指定することもできますし、結合定数の名前の中でワイルドカード文字 `#` を使うこともできます。`#` はサイトまたはボンドのタイプに置き換えられます。例えば次のとおりです。
 
     <HAMILTONIAN name="spin">
     <PARAMETER name="J" default="1"/>
@@ -62,10 +62,10 @@ Site-type dependent coupling terms can either be specified as in the first examp
     </BONDTERM>
     </HAMILTONIAN>
 
-We can now specify `h0` and `Gamma0` on sites of type 0 and `J0` on bonds of type 0, `h1`, `Gamma1`, and `J1` for type 1, and so on — this is exactly how, e.g., the `anisotropic2d` unit cell (see [A Library of Lattices and Graphs](../../latticehowtos/library)) lets a model assign different couplings `J0`/`J1` to bonds along each lattice direction. `J`, `h`, and `Gamma` here are the same parameters described in [ALPS Model Definitions](..).
+こうすることで、タイプ 0 のサイトには `h0` と `Gamma0` を、タイプ 0 のボンドには `J0` を、タイプ 1 には `h1`、`Gamma1`、`J1` を、というように指定できます——実際、例えば `anisotropic2d` 単位胞（[格子とグラフのライブラリ](../../latticehowtos/library)を参照）では、まさにこの仕組みによって、格子の各方向のボンドに異なる結合 `J0`/`J1` を割り当てることができます。ここでの `J`、`h`、`Gamma` は、[ALPS モデル定義](..)で説明されているものと同じパラメータです。
 
-Extensions to more complex terms, such as 3- and 4-site terms, are in preparation and will be included here as soon as the ALPS libraries support such terms.
+3 サイト項や 4 サイト項のような、より複雑な項への拡張は現在準備中であり、ALPS ライブラリがそのような項をサポートし次第、ここに追記される予定です。
 
 ---
 
-For an overview of the rest of this section, see [ALPS Model Definitions](..). For the operators used in these Hamiltonian terms, see [Quantum Operators](../operators). For the other ALPS documentation sections, see the [General Introduction](../..).
+本セクションの他のページの概要については [ALPS モデル定義](..) を参照してください。これらのハミルトニアン項で使われている演算子については [量子演算子](../operators) を参照してください。ALPS ドキュメントの他のセクションについては [総合案内](../..) を参照してください。

--- a/content/ja/documentation/intro/modeldef/intro.md
+++ b/content/ja/documentation/intro/modeldef/intro.md
@@ -1,54 +1,54 @@
 
 ---
-title: Introduction
+title: はじめに
 toc: true
 weight: 1
 ---
 
-As part of the ALPS project we need to describe quantum lattice models in a common XML format, separately from the lattice they live on. Keeping the model definition independent of the lattice means the same Hamiltonian (e.g. the Heisenberg model) can be simulated on any lattice, and the same simulation application can run any model, without changing any code.
+ALPS プロジェクトの一部として、量子格子モデルを、それが乗る格子とは切り離して共通の XML 形式で記述する必要があります。モデルの定義を格子から独立させておくことで、同じハミルトニアン（例えばハイゼンベルクモデル）をどんな格子上でもシミュレートでき、また同じシミュレーションアプリケーションでどんなモデルでも実行できるようになります。コードを変更する必要はありません。
 
-This page covers the following topics:
+このページでは、次のトピックを扱います。
 
-- [How to specify the basis of a single site](../sitebasis)
-- [How to combine single-site bases into the basis of the whole lattice](../latticebasis)
-- [How to define the quantum operators from which a Hamiltonian is built](../operators)
-- [How to assemble a Hamiltonian from parameters, a basis, and site/bond terms](../hamiltonian)
+- [単一サイトの基底を指定する方法](../sitebasis)
+- [単一サイトの基底を格子全体の基底へと組み合わせる方法](../latticebasis)
+- [ハミルトニアンを組み立てる量子演算子の定義方法](../operators)
+- [パラメータ、基底、サイト項/ボンド項からハミルトニアンを組み立てる方法](../hamiltonian)
 
-## The default model library file
+## デフォルトのモデルライブラリファイル
 
-The model library file defines the Hilbert space and the Hamiltonian of the problem. The default model library is found in `$ALPSPATH/lib/xml/models.xml`, and it contains many of the commonly used models:
+モデルライブラリファイルは、問題のヒルベルト空間とハミルトニアンを定義します。デフォルトのモデルライブラリは `$ALPSPATH/lib/xml/models.xml` にあり、よく使われる多くのモデルが含まれています。
 
-| **model name** | **list of available parameters** | **remark** |
+| **モデル名** | **利用可能なパラメータ一覧** | **備考** |
 | :------------- | :-------------------------------- | :--------- |
-| spin | J Jz Jxy J0 Jz0 Jxy0 J1 Jz1 Jxy1 h Gamma D K K0 K1 | anisotropic (XXZ) exchange, optionally with a field, single-ion anisotropy, and biquadratic terms |
-| boson Hubbard | mu t V U t0 t1 V0 V1 | |
-| hardcore boson | same as above | boson Hubbard model with on-site occupation restricted to 0 or 1, equivalent to the `U → ∞` limit |
-| fermion Hubbard | same as above | spinful fermions; `U` couples opposite-spin occupation on the same site |
-| spinless fermions | mu t V t0 t1 V0 V1 | no `U`, since two spinless fermions cannot occupy the same site |
-| Kondo lattice | mu t J | conduction electrons (`mu`, `t`) exchange-coupled (`J`) to localized spins |
-| t-J | mu t J V t0 t1 t2 V0 V1 V2 J0 J1 J2 | effective low-energy model for the Hubbard model in the large-`U` limit |
+| spin（スピン） | J Jz Jxy J0 Jz0 Jxy0 J1 Jz1 Jxy1 h Gamma D K K0 K1 | 異方的（XXZ）交換相互作用。磁場、一イオン異方性、双二次項をオプションで追加可能 |
+| boson Hubbard（ボーズ・ハバード） | mu t V U t0 t1 V0 V1 | |
+| hardcore boson（ハードコアボソン） | 上と同じ | サイトの占有数を 0 または 1 に制限したボーズ・ハバードモデル。`U → ∞` の極限に相当 |
+| fermion Hubbard（フェルミオン・ハバード） | 上と同じ | スピンを持つフェルミオン。`U` は同一サイト上の逆スピン占有数どうしを結合する |
+| spinless fermions（スピンレスフェルミオン） | mu t V t0 t1 V0 V1 | `U` は存在しない。2 つのスピンレスフェルミオンは同一サイトを占有できないため |
+| Kondo lattice（近藤格子） | mu t J | 伝導電子（`mu`、`t`）が局在スピンと交換相互作用（`J`）で結合する |
+| t-J | mu t J V t0 t1 t2 V0 V1 V2 J0 J1 J2 | 大きな `U` の極限におけるハバードモデルの有効低エネルギーモデル |
 
-The parameters above refer to the following physical quantities:
+上記のパラメータは、それぞれ次の物理量に対応します。
 
-| **symbol(s)** | **meaning** |
+| **記号** | **意味** |
 | :------------ | :---------- |
-| `mu` | chemical potential |
-| `t`, `t0`, `t1`, `t2` | hopping amplitude (site- or bond-type dependent) |
-| `U` | on-site interaction |
-| `V`, `V0`, `V1`, `V2` | nearest-neighbor (bond) interaction |
-| `J`, `J0`, `J1`, `J2` | isotropic exchange coupling, or the t-J model's superexchange |
-| `Jz`, `Jz0`, `Jz1` | Ising (`Sz·Sz`) part of an anisotropic (XXZ) exchange coupling |
-| `Jxy`, `Jxy0`, `Jxy1` | XY (transverse) part of an anisotropic exchange coupling |
-| `h` | uniform longitudinal field, coupling to `Sz` |
-| `Gamma` | transverse field, coupling to `Sx` |
-| `D` | single-ion anisotropy, coupling to `(Sz)^2` |
-| `K`, `K0`, `K1` | biquadratic exchange, coupling to `(Si·Sj)^2` |
+| `mu` | 化学ポテンシャル |
+| `t`、`t0`、`t1`、`t2` | ホッピング振幅（サイトまたはボンドのタイプに依存） |
+| `U` | オンサイト相互作用 |
+| `V`、`V0`、`V1`、`V2` | 最近接（ボンド）相互作用 |
+| `J`、`J0`、`J1`、`J2` | 等方的交換相互作用、または t-J モデルにおける超交換相互作用 |
+| `Jz`、`Jz0`、`Jz1` | 異方的（XXZ）交換相互作用のイジング（`Sz·Sz`）部分 |
+| `Jxy`、`Jxy0`、`Jxy1` | 異方的交換相互作用の XY（横成分）部分 |
+| `h` | `Sz` に結合する一様な縦磁場 |
+| `Gamma` | `Sx` に結合する横磁場 |
+| `D` | `(Sz)^2` に結合する一イオン異方性 |
+| `K`、`K0`、`K1` | `(Si·Sj)^2` に結合する双二次交換相互作用 |
 
-These models were introduced in the following original papers: the Heisenberg exchange model by [Heisenberg (1928)](https://doi.org/10.1007/BF01328601), the Hubbard model by [Hubbard (1963)](https://doi.org/10.1098/rspa.1963.0204), the Bose-Hubbard model by [Fisher et al. (1989)](https://doi.org/10.1103/PhysRevB.40.546), the Kondo lattice model by [Doniach (1977)](https://doi.org/10.1016/0378-4363(77)90190-5), and the t-J model by [Anderson (1987)](https://doi.org/10.1126/science.235.4793.1196) and [Zhang and Rice (1988)](https://doi.org/10.1103/PhysRevB.37.3759).
+これらのモデルは、それぞれ次の原論文で導入されました。ハイゼンベルク交換モデルは [Heisenberg (1928)](https://doi.org/10.1007/BF01328601)、ハバードモデルは [Hubbard (1963)](https://doi.org/10.1098/rspa.1963.0204)、ボーズ・ハバードモデルは [Fisher et al. (1989)](https://doi.org/10.1103/PhysRevB.40.546)、近藤格子モデルは [Doniach (1977)](https://doi.org/10.1016/0378-4363(77)90190-5)、t-J モデルは [Anderson (1987)](https://doi.org/10.1126/science.235.4793.1196) と [Zhang and Rice (1988)](https://doi.org/10.1103/PhysRevB.37.3759) によって導入されました。
 
-## General structure of a model library file
+## モデルライブラリファイルの一般的な構造
 
-The typical structure of a model library is the following:
+モデルライブラリの典型的な構造は次のとおりです。
 
     <MODEL>
     <SITEBASIS name="..."> ... </SITEBASIS>
@@ -56,8 +56,8 @@ The typical structure of a model library is the following:
     <HAMILTONIAN name="..."> ... </HAMILTONIAN>
     </MODEL>
 
-The `<SITEBASIS>` command defines the Hilbert space (basis) of a single site, the `<BASIS>` command defines the Hilbert space of the whole lattice, and the `<HAMILTONIAN>` defines the Hamiltonian.
+`<SITEBASIS>` は単一サイトのヒルベルト空間（基底）を、`<BASIS>` は格子全体のヒルベルト空間を、`<HAMILTONIAN>` はハミルトニアンを定義します。
 
 ---
 
-For an overview of the rest of this section, see [ALPS Model Definitions](..). For how the lattice itself is specified, see [Lattice Definitions](../../latticehowtos). For the other ALPS documentation sections, see the [General Introduction](../..).
+本セクションの他のページの概要については [ALPS モデル定義](..) を参照してください。格子そのものの指定方法については [格子定義](../../latticehowtos) を参照してください。ALPS ドキュメントの他のセクションについては [総合案内](../..) を参照してください。

--- a/content/ja/documentation/intro/modeldef/latticebasis.md
+++ b/content/ja/documentation/intro/modeldef/latticebasis.md
@@ -1,11 +1,11 @@
 
 ---
-title: Lattice Basis
+title: 格子基底
 toc: true
 weight: 3
 ---
 
-The basis of a lattice model is specified by giving a site basis for each type of site (vertex) in the lattice. If there is just one type of site, only one site basis needs to be given, either by referencing a previously defined [site basis](../sitebasis) or by declaring it inline:
+格子モデルの基底は、格子中の各サイト（頂点）タイプごとにサイト基底を与えることで指定します。サイトのタイプが 1 種類しかない場合は、サイト基底を 1 つだけ与えればよく、以前定義した[サイト基底](../sitebasis)を参照することも、その場でインラインに宣言することもできます。
 
     <BASIS name="spin">
     <SITEBASIS ref="spin"/>
@@ -18,20 +18,20 @@ The basis of a lattice model is specified by giving a site basis for each type o
     </SITEBASIS>
     </BASIS>
 
-Like `<SITEBASIS>`, the `<BASIS>` element takes a name attribute, by which it can later be referenced from a `<HAMILTONIAN>` (see [Hamiltonian Descriptions](../hamiltonian)). It contains a `<SITEBASIS>` element which is used as the default for all sites, either referencing a previously defined one by a ref attribute, as in the first example, or declaring the full site basis inline, as in the second. (The first example's `ref="spin"` points to the parametrized `spin` site basis defined in [Quantum Operators](../operators), used throughout the rest of this page.)
+`<SITEBASIS>` と同様、`<BASIS>` 要素も name 属性を持ち、後で `<HAMILTONIAN>` から参照できます（[ハミルトニアンの記述](../hamiltonian)を参照）。`<BASIS>` はすべてのサイトのデフォルトとして使われる `<SITEBASIS>` 要素を 1 つ含みます。これは、最初の例のように ref 属性で以前定義したサイト基底を参照することも、2 番目の例のようにサイト基底全体をインラインで宣言することもできます。（最初の例の `ref="spin"` は、[量子演算子](../operators)で定義されているパラメータ化された `spin` サイト基底を指しており、このページの残りの部分でもこれを使い続けます。）
 
-## Lattices with more than one site per unit cell
+## 単位胞に複数のサイトを持つ格子
 
-If the lattice contains more than one site per unit cell, the `<BASIS>` command should contain one `<SITEBASIS>` entry for each site of the unit cell. Each entry should have a different type, corresponding to the definitions given in the lattice library file (see [Lattice Definitions](../../latticehowtos)).
+格子の単位胞に複数のサイトが含まれる場合、`<BASIS>` コマンドには単位胞の各サイトに対応する `<SITEBASIS>` エントリを 1 つずつ含める必要があります。各エントリには、格子ライブラリファイル中の定義に対応する異なる type を指定します（[格子定義](../../latticehowtos)を参照）。
 
-The following basis is a valid example for the Hilbert space of a bipartite lattice:
+以下の基底は、二部格子のヒルベルト空間を表す有効な例です。
 
     <BASIS name="Kondo lattice">
     <SITEBASIS type="0" ref="fermion"/>
     <SITEBASIS type="1" ref="spin-1/2"/>
     </BASIS>
 
-In some spin models we might have the same local site basis but with the magnitude of the spin varying by site type. For example, we can set the value of the spin on sites of type 0 and 1 through the parameters `local_S0` and `local_S1`, while still providing suitable defaults:
+一部のスピンモデルでは、局所的なサイト基底自体は同じでも、スピンの大きさがサイトのタイプによって異なる場合があります。例えば、パラメータ `local_S0` と `local_S1` によってタイプ 0 とタイプ 1 のサイトのスピンの値を設定しつつ、適切なデフォルト値も用意することができます。
 
     <BASIS name="spin">
     <SITEBASIS type="0" ref="spin">
@@ -46,9 +46,9 @@ In some spin models we might have the same local site basis but with the magnitu
     </SITEBASIS>
     </BASIS>
 
-Here `local_spin` is the parameter the `spin` site basis itself uses internally to set `S` (see [Quantum Operators](../operators)); the chain of defaults means a user gets a sensible fallback at every level: leave everything unset and both site types get spin 1/2 from `local_S`; set `local_S=1` and both types become spin-1; or override `local_S0`/`local_S1` directly to give the two site types different spins.
+ここで `local_spin` は、`spin` サイト基底が内部で `S` を設定するために使っているパラメータです（[量子演算子](../operators)を参照）。このデフォルト値の連鎖により、どの段階でもユーザーに妥当なフォールバックが用意されます。何も設定しなければ、両方のサイトタイプは `local_S` によりスピン 1/2 になります。`local_S=1` と設定すれば両方のタイプがスピン 1 になります。あるいは `local_S0`/`local_S1` を直接上書きすれば、2 つのサイトタイプに異なるスピンを持たせることができます。
 
-When adding more site types this can become cumbersome, and the ALPS format allows a shortcut. If no `type` is specified, the `<SITEBASIS>` matches any site, and the wildcard character `#` in any parameter name is replaced by the site type. That way the above example can be extended to an infinite number of site types and written more compactly as:
+サイトタイプが増えるとこの書き方は煩雑になるため、ALPS の形式では簡略記法が用意されています。type を指定しなければ、`<SITEBASIS>` は任意のサイトにマッチし、パラメータ名中のワイルドカード文字 `#` はそのサイトのタイプに置き換えられます。これにより、上の例は無限個のサイトタイプに拡張しつつ、次のようにより簡潔に書くことができます。
 
     <BASIS name="spin">
     <SITEBASIS ref="spin">
@@ -58,17 +58,17 @@ When adding more site types this can become cumbersome, and the ALPS format allo
     </SITEBASIS>
     </BASIS>
 
-## Constraints
+## 制約
 
-Finally, the basis can be restricted to a sector where a quantum number, summed over all sites, takes a fixed value. For example, to restrict a spin basis to a fixed total `Sz` equal to the parameter `Sz_total`, a `<CONSTRAINT>` element can be added:
+最後に、基底はある量子数（全サイトについて和を取ったもの）が固定値を取るセクターに制限することもできます。例えば、スピン基底を全 `Sz` がパラメータ `Sz_total` に等しいセクターに制限するには、`<CONSTRAINT>` 要素を追加します。
 
     <BASIS name="spin">
     <SITEBASIS ref="spin"/>
     <CONSTRAINT quantumnumber="Sz" value="Sz_total"/>
     </BASIS>
 
-Restricting to a sector like this reduces the size of the Hilbert space, which matters most for methods that work with the full Hilbert space directly, such as exact diagonalization.
+このようにセクターに制限することでヒルベルト空間のサイズが縮小されます。これは、厳密対角化のようにヒルベルト空間全体を直接扱う手法にとって特に重要です。
 
 ---
 
-For an overview of the rest of this section, see [ALPS Model Definitions](..). For the single-site bases combined here, see [Site Basis](../sitebasis). For the other ALPS documentation sections, see the [General Introduction](../..).
+本セクションの他のページの概要については [ALPS モデル定義](..) を参照してください。ここで組み合わされている単一サイトの基底については [サイト基底](../sitebasis) を参照してください。ALPS ドキュメントの他のセクションについては [総合案内](../..) を参照してください。

--- a/content/ja/documentation/intro/modeldef/operators.md
+++ b/content/ja/documentation/intro/modeldef/operators.md
@@ -1,13 +1,13 @@
 
 ---
-title: Quantum Operators
+title: 量子演算子
 toc: true
 weight: 4
 ---
 
-## Simple site operators
+## 単純なサイト演算子
 
-The basic quantum operators from which the Hamiltonian operators will be built are specified by a name, a matrix element, and, optionally, the changes the operator causes to quantum numbers. These operators are defined within the site basis. Examples are:
+ハミルトニアンの演算子を組み立てる基本的な量子演算子は、名前、行列要素、そして（オプションで）その演算子が量子数に引き起こす変化によって指定されます。これらの演算子はサイト基底の中で定義されます。例えば次のとおりです。
 
     <SITEBASIS name="spin">
     <PARAMETER name="local_spin" default="1/2"/>
@@ -61,29 +61,29 @@ The basic quantum operators from which the Hamiltonian operators will be built a
     </OPERATOR>
     </SITEBASIS>
 
-Unlike `bdag`/`b`, the fermionic creation/annihilation operators `cdag_up`/`c_up` have a matrix element of plain `1` rather than a square root, since `Nup` only ever takes the two values 0 and 1: the `<QUANTUMNUMBER>`'s own `max="1"` already forbids double occupancy, so no occupation-dependent prefactor is needed. Declaring `Nup`/`Ndown` as `type="fermionic"` (as explained in [Site Basis](../sitebasis)) is what makes these operators anticommute correctly with fermionic operators on other sites — this is exactly what lets `cdag_up`/`c_up` be combined into the `fermion_hop` bond operator below.
+`bdag`/`b` とは異なり、フェルミオン的な生成・消滅演算子 `cdag_up`/`c_up` の行列要素は平方根ではなく単なる `1` です。これは `Nup` が 0 と 1 の 2 つの値しか取らないためです。`<QUANTUMNUMBER>` 自身の `max="1"` によってすでに二重占有が禁止されているため、占有数に依存する係数は不要です。`Nup`/`Ndown` を `type="fermionic"` として宣言すること（[サイト基底](../sitebasis)で説明済み）が、これらの演算子を他のサイトのフェルミオン演算子と正しく反交換させる理由であり、まさにこれによって下記の `fermion_hop` ボンド演算子で `cdag_up`/`c_up` を組み合わせることができます。
 
-The optional `<CHANGE>` element states that applying the operator shifts the given quantum number by the specified amount — `Splus` raises `Sz` by 1, `Sminus` lowers it by 1, and `bdag`/`b` raise/lower `N` by 1. An operator with no `<CHANGE>` element, like `Sz` or `n` above, is diagonal: it leaves every quantum number unchanged. In the specification of the matrix element, the value of the quantum numbers can be referred to through the name of the quantum number (`S`, `Sz`, `N` in these examples) — always evaluated using the values of the *initial* state, before the `<CHANGE>` is applied.
+オプションの `<CHANGE>` 要素は、その演算子を作用させると指定された量子数が指定量だけ変化することを表します —— `Splus` は `Sz` を 1 だけ増やし、`Sminus` は 1 だけ減らし、`bdag`/`b` は `N` を 1 だけ増減させます。上の `Sz` や `n` のように `<CHANGE>` 要素を持たない演算子は対角的であり、すべての量子数を変化させません。行列要素の表記の中では、量子数の名前（この例では `S`、`Sz`、`N`）を使ってその値を参照できます —— これは常に `<CHANGE>` が適用される前の*初期*状態の値で評価されます。
 
-## Complex site operators
+## 複合サイト演算子
 
-In addition to the simple site operators which change a quantum number in a unique way, one can construct more complex site operators such as the `Sx` spin operator:
+量子数を一意に変化させる単純なサイト演算子に加えて、例えば `Sx` スピン演算子のような、より複雑なサイト演算子を組み立てることもできます。
 
     <SITEOPERATOR name="Sx" site="i">
     1/2*(Splus(i)+Sminus(i))
     </SITEOPERATOR>
 
-or an operator counting on-site boson pairs, used e.g. in the on-site interaction term of the Bose-Hubbard Hamiltonian:
+あるいは、ボーズ・ハバードハミルトニアンのオンサイト相互作用項などで使われる、オンサイトのボソン対を数える演算子もあります。
 
     <SITEOPERATOR name="double_occupancy" site="x">
     n(x)*(n(x)-1)/2
     </SITEOPERATOR>
 
-These operator definitions can use any other simple or complex site operator. The argument given to the operator in parentheses is the symbolic name for the site, which is specified by the site attribute in the `<SITEOPERATOR>` element.
+これらの演算子の定義では、他の任意の単純または複合サイト演算子を使用できます。演算子に括弧付きで渡される引数は、そのサイトを表す記号名であり、`<SITEOPERATOR>` 要素の site 属性で指定されます。
 
-## Complex bond operators
+## 複合ボンド演算子
 
-Similar to the complex site operator, we can also define two-site, or bond, operators. The first example below is the Heisenberg exchange interaction `S(x)·S(y)`, written in terms of `Sz`, `Splus`, and `Sminus`; the second is a spin-conserving fermion hopping term, written in terms of independent up- and down-spin operators:
+複合サイト演算子と同様に、2 サイトにまたがる演算子、すなわちボンド演算子も定義できます。以下の最初の例は、`Sz`、`Splus`、`Sminus` を用いて書かれたハイゼンベルク交換相互作用 `S(x)·S(y)` です。2 番目の例は、独立なアップスピンおよびダウンスピン演算子を用いて書かれた、スピンを保存するフェルミオンのホッピング項です。
 
     <BONDOPERATOR name="exchange" source="x" target="y">
     Sz(x)*Sz(y)+1/2*(Splus(x)*Sminus(y)+Sminus(x)*Splus(y))
@@ -93,8 +93,8 @@ Similar to the complex site operator, we can also define two-site, or bond, oper
     cdag_up(x)*c_up(y)+cdag_up(y)*c_up(x)+cdag_down(x)*c_down(y)+cdag_down(y)*c_down(x)
     </BONDOPERATOR>
 
-where we now have two sites, labeled `source` and `target`. All the operators defined on this page — simple site, complex site, and bond — can be referenced by name in the `<SITETERM>`/`<BONDTERM>` elements of a `<HAMILTONIAN>` (see [Hamiltonian Descriptions](../hamiltonian)), and in custom measurement definitions (see [ALPS Custom Measurement](../../measuredef)).
+ここでは 2 つのサイトがあり、それぞれ source と target というラベルが付いています。このページで定義したすべての演算子 —— 単純なサイト演算子、複合サイト演算子、ボンド演算子 —— は、`<HAMILTONIAN>` の `<SITETERM>`/`<BONDTERM>` 要素の中で名前によって参照できるほか（[ハミルトニアンの記述](../hamiltonian)を参照）、カスタム測定の定義の中でも使用できます（[ALPS カスタム測定](../../measuredef)を参照）。
 
 ---
 
-For an overview of the rest of this section, see [ALPS Model Definitions](..). For how these operators are assembled into a Hamiltonian, see [Hamiltonian Descriptions](../hamiltonian). For the other ALPS documentation sections, see the [General Introduction](../..).
+本セクションの他のページの概要については [ALPS モデル定義](..) を参照してください。これらの演算子がどのようにハミルトニアンへと組み立てられるかについては [ハミルトニアンの記述](../hamiltonian) を参照してください。ALPS ドキュメントの他のセクションについては [総合案内](../..) を参照してください。

--- a/content/ja/documentation/intro/modeldef/sitebasis.md
+++ b/content/ja/documentation/intro/modeldef/sitebasis.md
@@ -1,11 +1,11 @@
 
 ---
-title: Site Basis
+title: サイト基底
 toc: true
 weight: 2
 ---
 
-Basis states of a single site are described by one or more quantum numbers as in:
+単一サイトの基底状態は、1 つ以上の量子数によって記述されます。例えば次のとおりです。
 
     <SITEBASIS name="hardcore boson">
     <QUANTUMNUMBER name="N" min="0" max="1"/>
@@ -21,20 +21,20 @@ Basis states of a single site are described by one or more quantum numbers as in
     <QUANTUMNUMBER name="Ndown" min="0" max="1" type="fermionic"/>
     </SITEBASIS>
 
-The first example above describes a hardcore boson (one bosonic mode with occupation restricted to 0 or 1), the second a spin-1/2, and the third a spinful fermion that allows double occupancy (independent `Nup` and `Ndown`, each ranging over 0 or 1).
+上の最初の例はハードコアボソン（占有数が 0 または 1 に制限された 1 つのボソンモード）を、2 番目はスピン 1/2 を、3 番目は二重占有を許すスピンを持つフェルミオン（独立な `Nup` と `Ndown` がそれぞれ 0 または 1 を取る）を表しています。
 
-Note that the spin-1/2 example above declares both `S` and `Sz`, even though `Sz` alone would already distinguish the two states: the total spin `S` is needed separately because it appears in the matrix elements of the spin operators defined in [Quantum Operators](../operators).
+上のスピン 1/2 の例では、`Sz` だけですでに 2 つの状態を区別できるにもかかわらず、`S` と `Sz` の両方が宣言されている点に注意してください。全スピン `S` を別途必要とするのは、[量子演算子](../operators)で定義されるスピン演算子の行列要素の中にそれが現れるためです。
 
-The `<SITEBASIS>` takes a name attribute by which it can later be referenced. The `<QUANTUMNUMBER>` elements each take a name attribute, and minimum and maximum values via the min and max attributes. The quantum numbers can take values between min, min+1, min+2 ... up to max. Optionally, a type attribute can be set to bosonic (the default) or fermionic. It should be set to fermionic when the quantum number counts a fermionic degree of freedom (e.g. a fermion occupation number), so that operators built from it anticommute correctly with fermionic operators on other sites.
+`<SITEBASIS>` には name 属性があり、後でこれを使って参照できます。各 `<QUANTUMNUMBER>` 要素には name 属性があり、min 属性と max 属性で最小値・最大値を指定します。量子数は min、min+1、min+2、…、max までの値を取ることができます。また、オプションとして type 属性に bosonic（ボソン的、デフォルト）または fermionic（フェルミオン的）を設定できます。この量子数がフェルミオン的自由度（例えばフェルミオンの占有数）を数えるものである場合には fermionic に設定すべきです。そうすることで、そこから作られる演算子が他のサイトのフェルミオン演算子と正しく反交換するようになります。
 
-The range of the quantum numbers can be parametrized by input parameters, and a `default` can be specified such as in
+量子数の取りうる範囲は入力パラメータによってパラメータ化でき、次のように `default` を指定することもできます。
 
     <SITEBASIS name="boson">
     <PARAMETER name="Nmax" default="infinity"/>
     <QUANTUMNUMBER name="N" min="0" max="Nmax"/>
     </SITEBASIS>
 
-For more complicated models, such as a t-J model, sometimes several equivalent choices of quantum numbers are possible. We can label the states either by the particle number and spin, or by the number of up and down spins:
+t-J モデルのようなより複雑なモデルでは、複数の等価な量子数の選び方が存在することがあります。状態を粒子数とスピンでラベル付けすることも、アップスピンとダウンスピンの数でラベル付けすることもできます。
 
     <SITEBASIS name="t-J">
     <QUANTUMNUMBER name="N" min="0" max="1" type="fermionic"/>
@@ -47,8 +47,8 @@ For more complicated models, such as a t-J model, sometimes several equivalent c
     <QUANTUMNUMBER name="Ndown" min="0" max="1-Nup" type="fermionic"/>
     </SITEBASIS>
 
-In the first version, `min="N/2" max="N/2"` pins `S` to exactly `N/2` rather than letting it range freely: an empty site (`N=0`) is forced to have `S=0`, and a singly occupied site (`N=1`) is forced to have `S=1/2`, which is exactly the no-double-occupancy constraint that defines the t-J model. The two site bases describe the same three physical states (empty, spin up, spin down) and are equally valid; which one is more convenient depends on the Hamiltonian: the `N`,`S` basis is natural when the total spin is a useful quantum number, while the `Nup`,`Ndown` basis is often simpler when writing operators that act separately on the up- and down-spin fermions, such as the `cdag_up`/`c_up` operators in the `fermion_hop` example in [Quantum Operators](../operators).
+最初のバージョンでは、`min="N/2" max="N/2"` によって `S` が自由に取りうる値ではなく厳密に `N/2` に固定されます。空のサイト（`N=0`）は必ず `S=0` となり、単一占有のサイト（`N=1`）は必ず `S=1/2` となります。これはまさに t-J モデルを定義する「二重占有禁止」の制約そのものです。この 2 つのサイト基底は、同じ 3 つの物理的な状態（空、アップスピン、ダウンスピン）を記述しており、どちらも同様に有効です。どちらがより便利かはハミルトニアンによります。全スピンが有用な量子数である場合は `N`、`S` 基底が自然であり、[量子演算子](../operators)の `fermion_hop` の例にある `cdag_up`/`c_up` のように、アップスピンとダウンスピンのフェルミオンにそれぞれ作用する演算子を書く場合には `Nup`、`Ndown` 基底の方がしばしば簡単です。
 
 ---
 
-For an overview of the rest of this section, see [ALPS Model Definitions](..). For how single-site bases are combined into the basis of the whole lattice, see [Lattice Basis](../latticebasis). For the other ALPS documentation sections, see the [General Introduction](../..).
+本セクションの他のページの概要については [ALPS モデル定義](..) を参照してください。単一サイトの基底が格子全体の基底へどのように組み合わされるかについては [格子基底](../latticebasis) を参照してください。ALPS ドキュメントの他のセクションについては [総合案内](../..) を参照してください。

--- a/content/zh-cn/documentation/intro/modeldef/_index.md
+++ b/content/zh-cn/documentation/intro/modeldef/_index.md
@@ -1,28 +1,28 @@
 
 ---
-title: ALPS Model Definitions
+title: ALPS 模型定义
 toc: true
 weight: 5
 ---
 
-As part of the ALPS project we need to describe quantum lattice models in a common XML format, independent of the lattice they run on (see [Lattice Definitions](../latticehowtos) for that half of an ALPS input file). This section builds that format up in stages: from the model library file and its overall `<MODEL>`/`<SITEBASIS>`/`<BASIS>`/`<HAMILTONIAN>` structure, through the basis of a single site and of the full lattice, to the quantum operators and Hamiltonian terms built from them.
+作为 ALPS 项目的一部分，我们需要用一种与运行模型的格子无关的通用 XML 格式来描述量子格点模型（格子部分参见[格子定义](../latticehowtos)）。本节将分阶段建立起这套格式：从模型库文件及其整体的 `<MODEL>`/`<SITEBASIS>`/`<BASIS>`/`<HAMILTONIAN>` 结构开始，依次讲解单个格点的基、整个格子的基，以及由它们构造出的量子算符和哈密顿量项。
 
-## [Introduction](intro)
+## [简介](intro)
 
-An overview of the ALPS model library file (`lib/xml/models.xml`), the built-in models it provides (spin, boson/fermion Hubbard, t-J, Kondo lattice, and more) with a glossary of their parameters and citations to the original papers, and the four-part `<MODEL>`/`<SITEBASIS>`/`<BASIS>`/`<HAMILTONIAN>` structure used to define a custom model.
+概述 ALPS 模型库文件（`lib/xml/models.xml`）、其内置的模型（自旋、玻色子/费米子 Hubbard 模型、t-J 模型、Kondo 晶格模型等），列出各模型参数的说明表并给出原始论文的引用，并介绍用于定义自定义模型的 `<MODEL>`/`<SITEBASIS>`/`<BASIS>`/`<HAMILTONIAN>` 四段式结构。
 
-## [Site Basis](sitebasis)
+## [格点基](sitebasis)
 
-How to describe the Hilbert space of a single site with one or more `<QUANTUMNUMBER>` elements, including fermionic vs. bosonic quantum numbers, parametrized ranges and defaults, and models such as the t-J model where several equivalent choices of quantum numbers are possible.
+如何用一个或多个 `<QUANTUMNUMBER>` 元素描述单个格点的希尔伯特空间，包括费米型与玻色型量子数的区别、参数化的取值范围与默认值，以及像 t-J 模型这样存在若干等价量子数选择的模型。
 
-## [Lattice Basis](latticebasis)
+## [格子基](latticebasis)
 
-How to combine single-site bases into the basis of the whole lattice with `<BASIS>`, covering lattices with more than one site per unit cell (including the `#` wildcard shortcut for per-type parameters), and how to restrict the basis with a `<CONSTRAINT>` on a summed quantum number (e.g. total `Sz`).
+如何用 `<BASIS>` 将单格点基组合成整个格子的基，涵盖每个晶胞包含多个格点的格子（包括用于按类型设置参数的 `#` 通配符简写），以及如何用 `<CONSTRAINT>` 对求和后的量子数（例如总 `Sz`）限制基的取值范围。
 
-## [Quantum Operators](operators)
+## [量子算符](operators)
 
-How to define the operators the Hamiltonian is built from: simple site operators with an explicit matrix element and quantum-number `<CHANGE>` (e.g. `Splus`, `bdag`, `cdag_up`), complex `<SITEOPERATOR>`s built from simpler ones (e.g. `Sx`), and two-site `<BONDOPERATOR>`s (e.g. `exchange`, `fermion_hop`).
+如何定义构造哈密顿量所用的算符：带有显式矩阵元和量子数 `<CHANGE>` 的简单格点算符（例如 `Splus`、`bdag`、`cdag_up`），由更简单的算符组合而成的复合 `<SITEOPERATOR>`（例如 `Sx`），以及双格点的 `<BONDOPERATOR>`（例如 `exchange`、`fermion_hop`）。
 
-## [Hamiltonian Descriptions](hamiltonian)
+## [哈密顿量描述](hamiltonian)
 
-How to assemble a `<HAMILTONIAN>` from `<PARAMETER>` defaults, a `<BASIS>` reference, and `<SITETERM>`/`<BONDTERM>` elements — including type-dependent couplings, either via an explicit `type` attribute or the `#` wildcard.
+如何用 `<PARAMETER>` 默认值、一个 `<BASIS>` 引用以及 `<SITETERM>`/`<BONDTERM>` 元素组装出一个 `<HAMILTONIAN>` —— 包括如何通过显式的 `type` 属性或 `#` 通配符实现依赖类型的耦合。

--- a/content/zh-cn/documentation/intro/modeldef/hamiltonian.md
+++ b/content/zh-cn/documentation/intro/modeldef/hamiltonian.md
@@ -1,11 +1,11 @@
 
 ---
-title: Hamiltonian Descriptions
+title: 哈密顿量描述
 toc: true
 weight: 5
 ---
 
-With these elements we can now describe the Hamiltonian of a model. A simple hardcore boson model could be:
+有了这些元素之后，我们现在就可以描述一个模型的哈密顿量了。一个简单的硬核玻色子模型可以写成：
 
     <HAMILTONIAN name="hardcore boson">
     <PARAMETER name="mu" default="0"/>
@@ -23,13 +23,13 @@ With these elements we can now describe the Hamiltonian of a model. A simple har
     </BONDTERM>
     </HAMILTONIAN>
 
-First, default values can be specified for parameters such as coupling constants by using `<PARAMETER>` elements. Next, one `<BASIS>` element specifies the basis used for the model, either fully specified inline or by a reference (using the `ref` attribute).
+首先，可以用 `<PARAMETER>` 元素为耦合常数等参数指定默认值。接下来，一个 `<BASIS>` 元素指定该模型所使用的基，既可以完全内联给出，也可以通过引用（使用 ref 属性）给出。
 
-The terms of the Hamiltonian are next specified by site terms, associated with the sites of the lattice, and bond terms, associated with the bonds. Each of the `<SITETERM>` and `<BONDTERM>` elements can optionally take a type attribute, specifying which type of site (or bond) the term applies to — the same types specified in the lattice description. Omitting the type attribute applies the term to all sites or bonds for which no other term is explicitly specified.
+哈密顿量的各项接下来由格点项和键项来指定：格点项与格子的格点相关联，键项与格子的键相关联。每个 `<SITETERM>` 和 `<BONDTERM>` 元素都可以选择性地带一个 type 属性，指定该项适用于哪种类型的格点（或键）——与格子描述中给出的类型相同。省略 type 属性会使该项应用于所有未被其他项显式指定的格点或键。
 
-The `<SITETERM>` elements contain terms of the Hamiltonian associated with a single site. In the above example the term `mu` refers to the parameter `mu` while the term `n` refers to the operator `n` described in [Quantum Operators](../operators). In the `<BONDTERM>` elements, the operators must refer to two different sites; this is done by adding the site index in parentheses after the operator, e.g. as in `n(i)` to act on site `i`. The source and target attributes name the variables used to refer to the two sites (`i` and `j` in the example).
+`<SITETERM>` 元素包含哈密顿量中与单个格点相关联的项。在上面的例子中，项 `mu` 指的是参数 `mu`，而项 `n` 指的是[量子算符](../operators)中描述的算符 `n`。在 `<BONDTERM>` 元素中，算符必须涉及两个不同的格点；这是通过在算符后面的括号中加入格点索引来实现的，例如用 `n(i)` 表示作用在格点 `i` 上。source 和 target 属性给出了用来指代这两个格点的变量名（在这个例子中是 `i` 和 `j`）。
 
-To simplify writing Hamiltonians, previously defined site and bond operators can be reused instead of writing out matrix elements again. For a transverse field spin model we can use the `Sx` and `exchange` operators defined in [Quantum Operators](../operators):
+为了简化哈密顿量的书写，可以直接重用之前定义好的格点算符和键算符，而不必重新写出矩阵元。对于一个横场自旋模型，我们可以使用[量子算符](../operators)中定义的 `Sx` 和 `exchange` 算符：
 
     <HAMILTONIAN name="spin">
     <PARAMETER name="J" default="1"/>
@@ -44,7 +44,7 @@ To simplify writing Hamiltonians, previously defined site and bond operators can
     </BONDTERM>
     </HAMILTONIAN>
 
-Site-type dependent coupling terms can either be specified as in the first example, giving a type attribute restricting the applicability of a site or bond term, or by using the `#` wildcard character in the name of coupling constants, which will be replaced by the type of the site or bond as in:
+依赖格点/键类型的耦合项既可以像第一个例子那样，通过 type 属性限定格点项或键项的适用范围来指定，也可以在耦合常数名称中使用 `#` 通配符字符，该字符会被替换为格点或键的类型，例如：
 
     <HAMILTONIAN name="spin">
     <PARAMETER name="J" default="1"/>
@@ -62,10 +62,10 @@ Site-type dependent coupling terms can either be specified as in the first examp
     </BONDTERM>
     </HAMILTONIAN>
 
-We can now specify `h0` and `Gamma0` on sites of type 0 and `J0` on bonds of type 0, `h1`, `Gamma1`, and `J1` for type 1, and so on — this is exactly how, e.g., the `anisotropic2d` unit cell (see [A Library of Lattices and Graphs](../../latticehowtos/library)) lets a model assign different couplings `J0`/`J1` to bonds along each lattice direction. `J`, `h`, and `Gamma` here are the same parameters described in [ALPS Model Definitions](..).
+这样我们就可以为类型 0 的格点指定 `h0` 和 `Gamma0`、为类型 0 的键指定 `J0`，为类型 1 指定 `h1`、`Gamma1` 和 `J1`，依此类推——例如，`anisotropic2d` 晶胞（参见[格子与图库](../../latticehowtos/library)）正是通过这种方式，让模型可以为沿不同格子方向的键分别指定不同的耦合 `J0`/`J1`。这里的 `J`、`h` 和 `Gamma` 与 [ALPS 模型定义](..)中描述的是同一批参数。
 
-Extensions to more complex terms, such as 3- and 4-site terms, are in preparation and will be included here as soon as the ALPS libraries support such terms.
+更复杂项的扩展，例如三格点项和四格点项，目前正在开发中，一旦 ALPS 库支持此类项，就会在此处补充说明。
 
 ---
 
-For an overview of the rest of this section, see [ALPS Model Definitions](..). For the operators used in these Hamiltonian terms, see [Quantum Operators](../operators). For the other ALPS documentation sections, see the [General Introduction](../..).
+关于本节其余部分的概览，参见 [ALPS 模型定义](..)。关于这些哈密顿量项中使用的算符，参见[量子算符](../operators)。关于 ALPS 文档的其他章节，参见[总体介绍](../..)。

--- a/content/zh-cn/documentation/intro/modeldef/intro.md
+++ b/content/zh-cn/documentation/intro/modeldef/intro.md
@@ -1,54 +1,54 @@
 
 ---
-title: Introduction
+title: 简介
 toc: true
 weight: 1
 ---
 
-As part of the ALPS project we need to describe quantum lattice models in a common XML format, separately from the lattice they live on. Keeping the model definition independent of the lattice means the same Hamiltonian (e.g. the Heisenberg model) can be simulated on any lattice, and the same simulation application can run any model, without changing any code.
+作为 ALPS 项目的一部分，我们需要用一种与格点模型所在的格子相互独立的通用 XML 格式来描述量子格点模型。让模型定义独立于格子，意味着同一个哈密顿量（例如海森堡模型）可以在任意格子上模拟，而同一个模拟程序也可以运行任意模型，都无需修改任何代码。
 
-This page covers the following topics:
+本页涵盖以下内容：
 
-- [How to specify the basis of a single site](../sitebasis)
-- [How to combine single-site bases into the basis of the whole lattice](../latticebasis)
-- [How to define the quantum operators from which a Hamiltonian is built](../operators)
-- [How to assemble a Hamiltonian from parameters, a basis, and site/bond terms](../hamiltonian)
+- [如何指定单个格点的基](../sitebasis)
+- [如何将单格点基组合成整个格子的基](../latticebasis)
+- [如何定义构造哈密顿量所用的量子算符](../operators)
+- [如何用参数、基以及格点/键项组装出哈密顿量](../hamiltonian)
 
-## The default model library file
+## 默认模型库文件
 
-The model library file defines the Hilbert space and the Hamiltonian of the problem. The default model library is found in `$ALPSPATH/lib/xml/models.xml`, and it contains many of the commonly used models:
+模型库文件定义了问题的希尔伯特空间和哈密顿量。默认的模型库位于 `$ALPSPATH/lib/xml/models.xml`，其中包含许多常用模型：
 
-| **model name** | **list of available parameters** | **remark** |
+| **模型名称** | **可用参数列表** | **备注** |
 | :------------- | :-------------------------------- | :--------- |
-| spin | J Jz Jxy J0 Jz0 Jxy0 J1 Jz1 Jxy1 h Gamma D K K0 K1 | anisotropic (XXZ) exchange, optionally with a field, single-ion anisotropy, and biquadratic terms |
-| boson Hubbard | mu t V U t0 t1 V0 V1 | |
-| hardcore boson | same as above | boson Hubbard model with on-site occupation restricted to 0 or 1, equivalent to the `U → ∞` limit |
-| fermion Hubbard | same as above | spinful fermions; `U` couples opposite-spin occupation on the same site |
-| spinless fermions | mu t V t0 t1 V0 V1 | no `U`, since two spinless fermions cannot occupy the same site |
-| Kondo lattice | mu t J | conduction electrons (`mu`, `t`) exchange-coupled (`J`) to localized spins |
-| t-J | mu t J V t0 t1 t2 V0 V1 V2 J0 J1 J2 | effective low-energy model for the Hubbard model in the large-`U` limit |
+| spin（自旋） | J Jz Jxy J0 Jz0 Jxy0 J1 Jz1 Jxy1 h Gamma D K K0 K1 | 各向异性（XXZ）交换耦合，可选带有外场、单离子各向异性和双二次项 |
+| boson Hubbard（玻色子 Hubbard） | mu t V U t0 t1 V0 V1 | |
+| hardcore boson（硬核玻色子） | 同上 | 格点占据数被限制为 0 或 1 的玻色子 Hubbard 模型，等价于 `U → ∞` 的极限 |
+| fermion Hubbard（费米子 Hubbard） | 同上 | 有自旋的费米子；`U` 耦合同一格点上相反自旋的占据数 |
+| spinless fermions（无自旋费米子） | mu t V t0 t1 V0 V1 | 没有 `U`，因为两个无自旋费米子不能占据同一格点 |
+| Kondo lattice（Kondo 晶格） | mu t J | 巡游电子（`mu`、`t`）与局域自旋通过交换耦合（`J`）相互作用 |
+| t-J | mu t J V t0 t1 t2 V0 V1 V2 J0 J1 J2 | Hubbard 模型在大 `U` 极限下的有效低能模型 |
 
-The parameters above refer to the following physical quantities:
+以上参数对应以下物理量：
 
-| **symbol(s)** | **meaning** |
+| **符号** | **含义** |
 | :------------ | :---------- |
-| `mu` | chemical potential |
-| `t`, `t0`, `t1`, `t2` | hopping amplitude (site- or bond-type dependent) |
-| `U` | on-site interaction |
-| `V`, `V0`, `V1`, `V2` | nearest-neighbor (bond) interaction |
-| `J`, `J0`, `J1`, `J2` | isotropic exchange coupling, or the t-J model's superexchange |
-| `Jz`, `Jz0`, `Jz1` | Ising (`Sz·Sz`) part of an anisotropic (XXZ) exchange coupling |
-| `Jxy`, `Jxy0`, `Jxy1` | XY (transverse) part of an anisotropic exchange coupling |
-| `h` | uniform longitudinal field, coupling to `Sz` |
-| `Gamma` | transverse field, coupling to `Sx` |
-| `D` | single-ion anisotropy, coupling to `(Sz)^2` |
-| `K`, `K0`, `K1` | biquadratic exchange, coupling to `(Si·Sj)^2` |
+| `mu` | 化学势 |
+| `t`、`t0`、`t1`、`t2` | 跃迁振幅（依赖格点或键的类型） |
+| `U` | 同一格点上的相互作用 |
+| `V`、`V0`、`V1`、`V2` | 最近邻（键）相互作用 |
+| `J`、`J0`、`J1`、`J2` | 各向同性交换耦合，或 t-J 模型中的超交换 |
+| `Jz`、`Jz0`、`Jz1` | 各向异性（XXZ）交换耦合中的伊辛（`Sz·Sz`）部分 |
+| `Jxy`、`Jxy0`、`Jxy1` | 各向异性交换耦合中的 XY（横向）部分 |
+| `h` | 均匀纵向场，与 `Sz` 耦合 |
+| `Gamma` | 横向场，与 `Sx` 耦合 |
+| `D` | 单离子各向异性，与 `(Sz)^2` 耦合 |
+| `K`、`K0`、`K1` | 双二次交换，与 `(Si·Sj)^2` 耦合 |
 
-These models were introduced in the following original papers: the Heisenberg exchange model by [Heisenberg (1928)](https://doi.org/10.1007/BF01328601), the Hubbard model by [Hubbard (1963)](https://doi.org/10.1098/rspa.1963.0204), the Bose-Hubbard model by [Fisher et al. (1989)](https://doi.org/10.1103/PhysRevB.40.546), the Kondo lattice model by [Doniach (1977)](https://doi.org/10.1016/0378-4363(77)90190-5), and the t-J model by [Anderson (1987)](https://doi.org/10.1126/science.235.4793.1196) and [Zhang and Rice (1988)](https://doi.org/10.1103/PhysRevB.37.3759).
+这些模型最初分别在以下论文中被提出：海森堡交换模型由 [Heisenberg (1928)](https://doi.org/10.1007/BF01328601) 提出，Hubbard 模型由 [Hubbard (1963)](https://doi.org/10.1098/rspa.1963.0204) 提出，玻色子 Hubbard 模型由 [Fisher et al. (1989)](https://doi.org/10.1103/PhysRevB.40.546) 提出，Kondo 晶格模型由 [Doniach (1977)](https://doi.org/10.1016/0378-4363(77)90190-5) 提出，t-J 模型则由 [Anderson (1987)](https://doi.org/10.1126/science.235.4793.1196) 和 [Zhang and Rice (1988)](https://doi.org/10.1103/PhysRevB.37.3759) 提出。
 
-## General structure of a model library file
+## 模型库文件的一般结构
 
-The typical structure of a model library is the following:
+模型库文件的典型结构如下：
 
     <MODEL>
     <SITEBASIS name="..."> ... </SITEBASIS>
@@ -56,8 +56,8 @@ The typical structure of a model library is the following:
     <HAMILTONIAN name="..."> ... </HAMILTONIAN>
     </MODEL>
 
-The `<SITEBASIS>` command defines the Hilbert space (basis) of a single site, the `<BASIS>` command defines the Hilbert space of the whole lattice, and the `<HAMILTONIAN>` defines the Hamiltonian.
+`<SITEBASIS>` 用于定义单个格点的希尔伯特空间（基），`<BASIS>` 用于定义整个格子的希尔伯特空间，`<HAMILTONIAN>` 用于定义哈密顿量。
 
 ---
 
-For an overview of the rest of this section, see [ALPS Model Definitions](..). For how the lattice itself is specified, see [Lattice Definitions](../../latticehowtos). For the other ALPS documentation sections, see the [General Introduction](../..).
+关于本节其余部分的概览，参见 [ALPS 模型定义](..)。关于格子本身如何指定，参见[格子定义](../../latticehowtos)。关于 ALPS 文档的其他章节，参见[总体介绍](../..)。

--- a/content/zh-cn/documentation/intro/modeldef/latticebasis.md
+++ b/content/zh-cn/documentation/intro/modeldef/latticebasis.md
@@ -1,11 +1,11 @@
 
 ---
-title: Lattice Basis
+title: 格子基
 toc: true
 weight: 3
 ---
 
-The basis of a lattice model is specified by giving a site basis for each type of site (vertex) in the lattice. If there is just one type of site, only one site basis needs to be given, either by referencing a previously defined [site basis](../sitebasis) or by declaring it inline:
+格子模型的基是通过为格子中每一种格点（顶点）类型给出一个格点基来指定的。如果格子中只有一种格点类型，那么只需给出一个格点基，既可以引用之前定义好的[格点基](../sitebasis)，也可以直接内联声明：
 
     <BASIS name="spin">
     <SITEBASIS ref="spin"/>
@@ -18,20 +18,20 @@ The basis of a lattice model is specified by giving a site basis for each type o
     </SITEBASIS>
     </BASIS>
 
-Like `<SITEBASIS>`, the `<BASIS>` element takes a name attribute, by which it can later be referenced from a `<HAMILTONIAN>` (see [Hamiltonian Descriptions](../hamiltonian)). It contains a `<SITEBASIS>` element which is used as the default for all sites, either referencing a previously defined one by a ref attribute, as in the first example, or declaring the full site basis inline, as in the second. (The first example's `ref="spin"` points to the parametrized `spin` site basis defined in [Quantum Operators](../operators), used throughout the rest of this page.)
+和 `<SITEBASIS>` 一样，`<BASIS>` 元素也有一个 name 属性，之后可以从 `<HAMILTONIAN>` 中引用它（参见[哈密顿量描述](../hamiltonian)）。它包含一个 `<SITEBASIS>` 元素，作为所有格点默认使用的基，既可以像第一个例子那样通过 ref 属性引用先前定义的格点基，也可以像第二个例子那样内联声明完整的格点基。（第一个例子中的 `ref="spin"` 指向[量子算符](../operators)中定义的参数化 `spin` 格点基，本页其余部分都会用到它。）
 
-## Lattices with more than one site per unit cell
+## 每个晶胞包含多个格点的格子
 
-If the lattice contains more than one site per unit cell, the `<BASIS>` command should contain one `<SITEBASIS>` entry for each site of the unit cell. Each entry should have a different type, corresponding to the definitions given in the lattice library file (see [Lattice Definitions](../../latticehowtos)).
+如果格子的晶胞包含多个格点，`<BASIS>` 命令中应该为晶胞的每个格点各包含一个 `<SITEBASIS>` 条目，每个条目应有不同的 type，与格子库文件中给出的定义相对应（参见[格子定义](../../latticehowtos)）。
 
-The following basis is a valid example for the Hilbert space of a bipartite lattice:
+下面的基是一个二分格子希尔伯特空间的有效示例：
 
     <BASIS name="Kondo lattice">
     <SITEBASIS type="0" ref="fermion"/>
     <SITEBASIS type="1" ref="spin-1/2"/>
     </BASIS>
 
-In some spin models we might have the same local site basis but with the magnitude of the spin varying by site type. For example, we can set the value of the spin on sites of type 0 and 1 through the parameters `local_S0` and `local_S1`, while still providing suitable defaults:
+在某些自旋模型中，我们可能希望不同格点类型使用相同的局域格点基，但自旋大小随格点类型而不同。例如，我们可以通过参数 `local_S0` 和 `local_S1` 分别设置类型 0 和类型 1 格点上的自旋值，同时仍然提供合理的默认值：
 
     <BASIS name="spin">
     <SITEBASIS type="0" ref="spin">
@@ -46,9 +46,9 @@ In some spin models we might have the same local site basis but with the magnitu
     </SITEBASIS>
     </BASIS>
 
-Here `local_spin` is the parameter the `spin` site basis itself uses internally to set `S` (see [Quantum Operators](../operators)); the chain of defaults means a user gets a sensible fallback at every level: leave everything unset and both site types get spin 1/2 from `local_S`; set `local_S=1` and both types become spin-1; or override `local_S0`/`local_S1` directly to give the two site types different spins.
+这里 `local_spin` 是 `spin` 格点基内部用来设置 `S` 的参数（参见[量子算符](../operators)）；这条默认值链条使得用户在每一层都能得到一个合理的回退值：如果什么都不设置，两种格点类型都会通过 `local_S` 得到自旋 1/2；设置 `local_S=1` 后两种类型都变为自旋 1；也可以直接覆盖 `local_S0`/`local_S1`，让两种格点类型拥有不同的自旋。
 
-When adding more site types this can become cumbersome, and the ALPS format allows a shortcut. If no `type` is specified, the `<SITEBASIS>` matches any site, and the wildcard character `#` in any parameter name is replaced by the site type. That way the above example can be extended to an infinite number of site types and written more compactly as:
+当格点类型增多时，这种写法会变得繁琐，为此 ALPS 格式提供了一种简写。如果没有指定 type，`<SITEBASIS>` 将匹配任意格点，并且参数名中的通配符 `#` 会被替换为该格点的类型。这样一来，上面的例子就可以扩展到任意多种格点类型，并更紧凑地写成：
 
     <BASIS name="spin">
     <SITEBASIS ref="spin">
@@ -58,17 +58,17 @@ When adding more site types this can become cumbersome, and the ALPS format allo
     </SITEBASIS>
     </BASIS>
 
-## Constraints
+## 约束
 
-Finally, the basis can be restricted to a sector where a quantum number, summed over all sites, takes a fixed value. For example, to restrict a spin basis to a fixed total `Sz` equal to the parameter `Sz_total`, a `<CONSTRAINT>` element can be added:
+最后，基还可以被限制在某个扇区中，在该扇区内某个对所有格点求和后的量子数取固定值。例如，要将自旋基限制在总 `Sz` 等于参数 `Sz_total` 的扇区，可以添加一个 `<CONSTRAINT>` 元素：
 
     <BASIS name="spin">
     <SITEBASIS ref="spin"/>
     <CONSTRAINT quantumnumber="Sz" value="Sz_total"/>
     </BASIS>
 
-Restricting to a sector like this reduces the size of the Hilbert space, which matters most for methods that work with the full Hilbert space directly, such as exact diagonalization.
+像这样限制到某个扇区可以缩小希尔伯特空间的规模，这对于直接在完整希尔伯特空间中工作的方法（例如精确对角化）尤其重要。
 
 ---
 
-For an overview of the rest of this section, see [ALPS Model Definitions](..). For the single-site bases combined here, see [Site Basis](../sitebasis). For the other ALPS documentation sections, see the [General Introduction](../..).
+关于本节其余部分的概览，参见 [ALPS 模型定义](..)。关于这里组合所用的单格点基，参见[格点基](../sitebasis)。关于 ALPS 文档的其他章节，参见[总体介绍](../..)。

--- a/content/zh-cn/documentation/intro/modeldef/operators.md
+++ b/content/zh-cn/documentation/intro/modeldef/operators.md
@@ -1,13 +1,13 @@
 
 ---
-title: Quantum Operators
+title: 量子算符
 toc: true
 weight: 4
 ---
 
-## Simple site operators
+## 简单格点算符
 
-The basic quantum operators from which the Hamiltonian operators will be built are specified by a name, a matrix element, and, optionally, the changes the operator causes to quantum numbers. These operators are defined within the site basis. Examples are:
+用于构造哈密顿量算符的基本量子算符由名称、矩阵元以及（可选的）该算符对量子数造成的改变来指定。这些算符是在格点基内部定义的。例如：
 
     <SITEBASIS name="spin">
     <PARAMETER name="local_spin" default="1/2"/>
@@ -61,29 +61,29 @@ The basic quantum operators from which the Hamiltonian operators will be built a
     </OPERATOR>
     </SITEBASIS>
 
-Unlike `bdag`/`b`, the fermionic creation/annihilation operators `cdag_up`/`c_up` have a matrix element of plain `1` rather than a square root, since `Nup` only ever takes the two values 0 and 1: the `<QUANTUMNUMBER>`'s own `max="1"` already forbids double occupancy, so no occupation-dependent prefactor is needed. Declaring `Nup`/`Ndown` as `type="fermionic"` (as explained in [Site Basis](../sitebasis)) is what makes these operators anticommute correctly with fermionic operators on other sites — this is exactly what lets `cdag_up`/`c_up` be combined into the `fermion_hop` bond operator below.
+与 `bdag`/`b` 不同，费米型的产生/湮灭算符 `cdag_up`/`c_up` 的矩阵元只是简单的 `1`，而不是平方根形式，这是因为 `Nup` 只能取 0 和 1 这两个值：`<QUANTUMNUMBER>` 本身的 `max="1"` 已经禁止了双占据，因此不需要依赖占据数的前置系数。将 `Nup`/`Ndown` 声明为 `type="fermionic"`（如[格点基](../sitebasis)中所述）正是使这些算符能与其他格点上的费米算符正确反对易的原因 —— 这也正是下面 `cdag_up`/`c_up` 能够被组合成 `fermion_hop` 键算符的原因。
 
-The optional `<CHANGE>` element states that applying the operator shifts the given quantum number by the specified amount — `Splus` raises `Sz` by 1, `Sminus` lowers it by 1, and `bdag`/`b` raise/lower `N` by 1. An operator with no `<CHANGE>` element, like `Sz` or `n` above, is diagonal: it leaves every quantum number unchanged. In the specification of the matrix element, the value of the quantum numbers can be referred to through the name of the quantum number (`S`, `Sz`, `N` in these examples) — always evaluated using the values of the *initial* state, before the `<CHANGE>` is applied.
+可选的 `<CHANGE>` 元素说明施加该算符会使给定的量子数改变指定的量 —— `Splus` 使 `Sz` 增加 1，`Sminus` 使其减少 1，而 `bdag`/`b` 使 `N` 增加/减少 1。没有 `<CHANGE>` 元素的算符，例如上面的 `Sz` 或 `n`，是对角的：它不改变任何量子数。在矩阵元的表达式中，可以通过量子数的名称（本例中的 `S`、`Sz`、`N`）来引用其取值——这些取值总是按照*施加 `<CHANGE>` 之前*的初始态来求值。
 
-## Complex site operators
+## 复合格点算符
 
-In addition to the simple site operators which change a quantum number in a unique way, one can construct more complex site operators such as the `Sx` spin operator:
+除了以唯一方式改变某个量子数的简单格点算符之外，我们还可以构造更复杂的格点算符，例如 `Sx` 自旋算符：
 
     <SITEOPERATOR name="Sx" site="i">
     1/2*(Splus(i)+Sminus(i))
     </SITEOPERATOR>
 
-or an operator counting on-site boson pairs, used e.g. in the on-site interaction term of the Bose-Hubbard Hamiltonian:
+或者用于计数同一格点上玻色子对数目的算符，例如出现在 Bose-Hubbard 哈密顿量的在位相互作用项中：
 
     <SITEOPERATOR name="double_occupancy" site="x">
     n(x)*(n(x)-1)/2
     </SITEOPERATOR>
 
-These operator definitions can use any other simple or complex site operator. The argument given to the operator in parentheses is the symbolic name for the site, which is specified by the site attribute in the `<SITEOPERATOR>` element.
+这些算符定义可以使用任何其他简单或复合的格点算符。给算符的括号中传入的参数是该格点的符号名，由 `<SITEOPERATOR>` 元素中的 site 属性指定。
 
-## Complex bond operators
+## 复合键算符
 
-Similar to the complex site operator, we can also define two-site, or bond, operators. The first example below is the Heisenberg exchange interaction `S(x)·S(y)`, written in terms of `Sz`, `Splus`, and `Sminus`; the second is a spin-conserving fermion hopping term, written in terms of independent up- and down-spin operators:
+与复合格点算符类似，我们也可以定义作用于两个格点的键算符。下面第一个例子是用 `Sz`、`Splus` 和 `Sminus` 写出的海森堡交换相互作用 `S(x)·S(y)`；第二个例子是用独立的向上、向下自旋算符写出的、保持自旋守恒的费米子跃迁项：
 
     <BONDOPERATOR name="exchange" source="x" target="y">
     Sz(x)*Sz(y)+1/2*(Splus(x)*Sminus(y)+Sminus(x)*Splus(y))
@@ -93,8 +93,8 @@ Similar to the complex site operator, we can also define two-site, or bond, oper
     cdag_up(x)*c_up(y)+cdag_up(y)*c_up(x)+cdag_down(x)*c_down(y)+cdag_down(y)*c_down(x)
     </BONDOPERATOR>
 
-where we now have two sites, labeled `source` and `target`. All the operators defined on this page — simple site, complex site, and bond — can be referenced by name in the `<SITETERM>`/`<BONDTERM>` elements of a `<HAMILTONIAN>` (see [Hamiltonian Descriptions](../hamiltonian)), and in custom measurement definitions (see [ALPS Custom Measurement](../../measuredef)).
+这里我们有两个格点，分别标记为 source 和 target。本页定义的所有算符——简单格点算符、复合格点算符和键算符——都可以在 `<HAMILTONIAN>` 的 `<SITETERM>`/`<BONDTERM>` 元素中按名称引用（参见[哈密顿量描述](../hamiltonian)），也可以在自定义测量的定义中使用（参见 [ALPS 自定义测量](../../measuredef)）。
 
 ---
 
-For an overview of the rest of this section, see [ALPS Model Definitions](..). For how these operators are assembled into a Hamiltonian, see [Hamiltonian Descriptions](../hamiltonian). For the other ALPS documentation sections, see the [General Introduction](../..).
+关于本节其余部分的概览，参见 [ALPS 模型定义](..)。关于如何将这些算符组装成哈密顿量，参见[哈密顿量描述](../hamiltonian)。关于 ALPS 文档的其他章节，参见[总体介绍](../..)。

--- a/content/zh-cn/documentation/intro/modeldef/sitebasis.md
+++ b/content/zh-cn/documentation/intro/modeldef/sitebasis.md
@@ -1,11 +1,11 @@
 
 ---
-title: Site Basis
+title: 格点基
 toc: true
 weight: 2
 ---
 
-Basis states of a single site are described by one or more quantum numbers as in:
+单个格点的基态由一个或多个量子数描述，例如：
 
     <SITEBASIS name="hardcore boson">
     <QUANTUMNUMBER name="N" min="0" max="1"/>
@@ -21,20 +21,20 @@ Basis states of a single site are described by one or more quantum numbers as in
     <QUANTUMNUMBER name="Ndown" min="0" max="1" type="fermionic"/>
     </SITEBASIS>
 
-The first example above describes a hardcore boson (one bosonic mode with occupation restricted to 0 or 1), the second a spin-1/2, and the third a spinful fermion that allows double occupancy (independent `Nup` and `Ndown`, each ranging over 0 or 1).
+上面第一个例子描述了一个硬核玻色子（一个玻色模式，占据数被限制为 0 或 1），第二个描述了一个自旋 1/2，第三个描述了一个允许双占据的有自旋费米子（独立的 `Nup` 和 `Ndown`，各自取值 0 或 1）。
 
-Note that the spin-1/2 example above declares both `S` and `Sz`, even though `Sz` alone would already distinguish the two states: the total spin `S` is needed separately because it appears in the matrix elements of the spin operators defined in [Quantum Operators](../operators).
+请注意，上面自旋 1/2 的例子同时声明了 `S` 和 `Sz`，尽管仅凭 `Sz` 就已经足以区分这两个态：之所以还需要单独给出总自旋 `S`，是因为它会出现在[量子算符](../operators)所定义的自旋算符的矩阵元中。
 
-The `<SITEBASIS>` takes a name attribute by which it can later be referenced. The `<QUANTUMNUMBER>` elements each take a name attribute, and minimum and maximum values via the min and max attributes. The quantum numbers can take values between min, min+1, min+2 ... up to max. Optionally, a type attribute can be set to bosonic (the default) or fermionic. It should be set to fermionic when the quantum number counts a fermionic degree of freedom (e.g. a fermion occupation number), so that operators built from it anticommute correctly with fermionic operators on other sites.
+`<SITEBASIS>` 有一个 name 属性，之后可以通过它来引用该基。每个 `<QUANTUMNUMBER>` 元素都有一个 name 属性，并通过 min 和 max 属性给出取值的上下限。量子数可以取 min、min+1、min+2……直到 max 之间的值。此外还可以选择性地设置 type 属性为 bosonic（玻色型，默认值）或 fermionic（费米型）。当该量子数计数的是费米型自由度（例如费米子占据数）时，应将其设为 fermionic，这样由它构造出的算符才能与其他格点上的费米算符正确地反对易。
 
-The range of the quantum numbers can be parametrized by input parameters, and a `default` can be specified such as in
+量子数的取值范围可以通过输入参数来参数化，并可以指定一个 `default` 默认值，例如：
 
     <SITEBASIS name="boson">
     <PARAMETER name="Nmax" default="infinity"/>
     <QUANTUMNUMBER name="N" min="0" max="Nmax"/>
     </SITEBASIS>
 
-For more complicated models, such as a t-J model, sometimes several equivalent choices of quantum numbers are possible. We can label the states either by the particle number and spin, or by the number of up and down spins:
+对于更复杂的模型，例如 t-J 模型，有时会存在若干等价的量子数选择。我们既可以用粒子数和自旋来标记态，也可以用向上自旋数和向下自旋数来标记：
 
     <SITEBASIS name="t-J">
     <QUANTUMNUMBER name="N" min="0" max="1" type="fermionic"/>
@@ -47,8 +47,8 @@ For more complicated models, such as a t-J model, sometimes several equivalent c
     <QUANTUMNUMBER name="Ndown" min="0" max="1-Nup" type="fermionic"/>
     </SITEBASIS>
 
-In the first version, `min="N/2" max="N/2"` pins `S` to exactly `N/2` rather than letting it range freely: an empty site (`N=0`) is forced to have `S=0`, and a singly occupied site (`N=1`) is forced to have `S=1/2`, which is exactly the no-double-occupancy constraint that defines the t-J model. The two site bases describe the same three physical states (empty, spin up, spin down) and are equally valid; which one is more convenient depends on the Hamiltonian: the `N`,`S` basis is natural when the total spin is a useful quantum number, while the `Nup`,`Ndown` basis is often simpler when writing operators that act separately on the up- and down-spin fermions, such as the `cdag_up`/`c_up` operators in the `fermion_hop` example in [Quantum Operators](../operators).
+在第一种写法中，`min="N/2" max="N/2"` 将 `S` 精确地固定为 `N/2`，而不是让它自由取值：空格点（`N=0`）被迫具有 `S=0`，单占据格点（`N=1`）被迫具有 `S=1/2`，这正好就是定义 t-J 模型所需的“禁止双占据”约束。这两种格点基描述的是同样的三个物理态（空、自旋向上、自旋向下），两者同样有效；具体用哪一种更方便取决于哈密顿量：当总自旋是一个有用的量子数时，`N`、`S` 基更自然；而在编写分别作用于向上、向下自旋费米子的算符时，例如[量子算符](../operators)中 `fermion_hop` 例子里的 `cdag_up`/`c_up` 算符，`Nup`、`Ndown` 基往往更简单。
 
 ---
 
-For an overview of the rest of this section, see [ALPS Model Definitions](..). For how single-site bases are combined into the basis of the whole lattice, see [Lattice Basis](../latticebasis). For the other ALPS documentation sections, see the [General Introduction](../..).
+关于本节其余部分的概览，参见 [ALPS 模型定义](..)。关于如何将单格点基组合成整个格子的基，参见[格子基](../latticebasis)。关于 ALPS 文档的其他章节，参见[总体介绍](../..)。


### PR DESCRIPTION
## Summary
- Fully translates the `zh-cn` and `ja` copies of the [ALPS Model Definitions](https://alps.comp-phys.org/documentation/intro/modeldef/) section, which had been verbatim English copies since the section was split out of a single `modeldef.md` page (PR #112).
- Covers all 6 pages: `_index.md`, `intro.md`, `sitebasis.md`, `latticebasis.md`, `operators.md`, `hamiltonian.md`.
- Prose, headings, and table content are translated; XML examples (`<SITEBASIS>`, `<BASIS>`, `<HAMILTONIAN>`, etc.), parameter names, and operator names are left verbatim — same convention already used for the alpsize/Integration section and the measuredef page (PR #113).

## Test plan
- [x] `hugo --gc` builds cleanly across all three language trees
- [x] Spot-checked rendered `zh-cn` and `ja` pages: code blocks preserved verbatim, prose translated, breadcrumbs show translated section titles
- [x] Verified all internal relative links in both translated trees resolve to the correct generated URLs
