### PR TITLE
Feat/cta button color option

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -21,7 +21,7 @@ Since its inception, ALPS has been used by hundreds of researchers across at lea
 </div>
 
 <div class="btn-grid">
-{{< cta-button text="Get Started" link="start" icon="rocket_launch" >}}
+{{< cta-button text="Get Started" link="start" icon="rocket_launch" color="#3B5B8C" >}}
 {{< cta-button text="GitHub Source" link="https://github.com/ALPSim/ALPS" icon="code" >}}
 {{< cta-button text="Events" link="events" icon="event" >}}
 {{< cta-button text="Installation" link="install" icon="download" >}}

--- a/layouts/shortcodes/cta-button.html
+++ b/layouts/shortcodes/cta-button.html
@@ -3,11 +3,11 @@
 {{- $text := .Get "text" -}}
 {{- $prim := .Get "prim" -}}
 {{- $error := .Get "err" -}}
-
+{{- $color := .Get "color" -}}
 {{- $external := hasPrefix $link "http" -}}
 {{- $href := cond (hasPrefix $link "/") ($link | relURL) $link -}}
-
 <a href="{{- $href -}}" class="btn {{ if $prim }}btn-primary{{ else if $error }}btn-outlined-error{{ else }}btn-outlined-primary{{ end }}"
+  {{ with $color }}style="background-color: {{ . }}; border-color: {{ . }};"{{ end }}
   {{ if $external }}target="_blank" rel="noreferrer"{{ end -}}>
   <span class="material-icons">{{ $icon }}</span>
   {{ with $text }}{{ . }}{{ end }}


### PR DESCRIPTION
Looking at the Google analytics page many **first time users** will bounce around between links, eventually arriving at a download page. There could be many reasons for this (e.g. user looks at tutorials first, then decides to try the install).

This patch puts in the option of having a colored button (optional parameter) and applies that to the "Get Started" link. The purpose is to break some symmetry on the page, guiding a new user to this button, while not messing with the layout. This is probably the link most new users should click first, so this might help with navigation.

The color can easily be changed, and reverted back to default.