### PR TITLE
Convert tutorial spellings from British to American English

### DIFF
--- a/content/en/tutorials/_index.md
+++ b/content/en/tutorials/_index.md
@@ -9,7 +9,7 @@ cascade:
     type: docs
 ---
 These tutorials guide you through the major simulation methods available in ALPS, from classical and quantum Monte Carlo to tensor-network and mean-field approaches.
-Each tutorial sets up a concrete model — typically a spin chain, Hubbard model, or Bose-Hubbard system — and walks through choosing parameters, running the simulation, and analysing the output.
+Each tutorial sets up a concrete model — typically a spin chain, Hubbard model, or Bose-Hubbard system — and walks through choosing parameters, running the simulation, and analyzing the output.
 The example systems are intentionally small so that every calculation completes in minutes on a laptop.
 All tutorials are available as Python scripts; a growing collection of [Jupyter Notebooks](jupyter) provides an interactive alternative.
 
@@ -26,7 +26,7 @@ Topics include sparse Lanczos diagonalization, spin-gap scaling in one-dimension
 ## [Density Matrix Renormalization Group (DMRG)](dmrg)
 
 Tutorials for the DMRG method applied to one-dimensional quantum systems.
-The series introduces the algorithm and its convergence, then demonstrates how to extract energy gaps, measure local observables such as magnetization profiles, and compute two-point correlation functions — key quantities for identifying quantum phases and critical behaviour.
+The series introduces the algorithm and its convergence, then demonstrates how to extract energy gaps, measure local observables such as magnetization profiles, and compute two-point correlation functions — key quantities for identifying quantum phases and critical behavior.
 
 ## [Dynamical Mean Field Theory (DMFT)](dmft)
 
@@ -40,7 +40,7 @@ These tutorials bridge the gap between the built-in ALPS library and the full ge
 
 ## [Jupyter Notebooks](jupyter)
 
-Interactive Jupyter notebook versions of selected ALPS tutorials, organised by method.
+Interactive Jupyter notebook versions of selected ALPS tutorials, organized by method.
 Each notebook combines code, equations, and plots in a single document that can be downloaded and run locally, making it straightforward to modify parameters and explore results interactively.
 
 

--- a/content/en/tutorials/dmrg/dmrg01.md
+++ b/content/en/tutorials/dmrg/dmrg01.md
@@ -13,7 +13,7 @@ $$
 H = J\sum_{i=1}^{L-1} \left[\frac{1}{2} (S^+_i S^-_{i+1} + S^-_i S^+_{i+1}) + S^z_i S^z_{i+1}\right] .
 $$
 
-The reason why we are choosing these two models, which you may already know from other tutorials, is that despite their superficial similarity they exhibit completely different physical behaviour and pose very different challenges to the DMRG algorithm. Let us briefly review their physical properties.
+The reason why we are choosing these two models, which you may already know from other tutorials, is that despite their superficial similarity they exhibit completely different physical behavior and pose very different challenges to the DMRG algorithm. Let us briefly review their physical properties.
 
 ### Spin-1/2 Chain
 
@@ -53,7 +53,7 @@ $$
 
 to five-digit accuracy.
 
-The question for the behaviour of the spin-spin correlations leads to yet another big difference to the spin-1/2 case. The correlations read asymptotically (i.e. for $|i-j| \rightarrow \infty$)
+The question for the behavior of the spin-spin correlations leads to yet another big difference to the spin-1/2 case. The correlations read asymptotically (i.e. for $|i-j| \rightarrow \infty$)
 
 $$
  \langle S^z_i S^z_j \rangle \sim (-1)^{|i-j|} \frac{\exp (-|i-j|/\xi)}{\sqrt{|i-j|}}  .
@@ -83,7 +83,7 @@ The second key control parameter is of course the system size $L$.
 
 The third control parameter(s) can only be understood by looking even closer at the DMRG algorithm. In order to find the best approximation to a state, DMRG proceeds in two steps:
 
-1. In a first step (so-called *infinite-system* DMRG) the algorithm tries to find good subspaces by iteratively analyzing chains of length 2, 4, 6, until the desired system size $L$ is reached. The procedure consists of splitting the chain in every iteration and insert two new sites at the center; the name comes from the fact that this procedure can of course be carried on infinitely, to take $L$ to infinity; but don't expect very meaningful results as you approach infinity! A second remark is that this procedure favours chains of even length for DMRG treatment.
+1. In a first step (so-called *infinite-system* DMRG) the algorithm tries to find good subspaces by iteratively analyzing chains of length 2, 4, 6, until the desired system size $L$ is reached. The procedure consists of splitting the chain in every iteration and insert two new sites at the center; the name comes from the fact that this procedure can of course be carried on infinitely, to take $L$ to infinity; but don't expect very meaningful results as you approach infinity! A second remark is that this procedure favors chains of even length for DMRG treatment.
 2. In a second step (so-called *finite-system* DMRG) DMRG deals with the fact that the subspace selection for shorter chains could not yet take into account all the quantum fluctuations and correlations that would be present in the chain of final length $L$. What the method does, is to go through a series of further iterations to improve the quality of the subspaces. One such iteration visiting all sites of a chain is referred to as a *sweep* in DMRG. The number of sweeps is the last important control parameter: if it is too small, the precision of the results for a given $D$ is not achieved; if it is too large, the calculational effort could be wasted, although it is of course always good to err on the safe side.
 
 In a last remark, let us consider the *truncation error*, which is a good indicator of the accuracy achieved by a DMRG run. In a simplified perspective, at each point in the algorithm DMRG makes one step in the direction of exponential growth of state space and then asks how much accuracy can be retained if not allowing that step, by means of an analysis of a density matrix regarding the distribution of weights (eigenvalues) corresponding to its eigenstates. The approximations of DMRG are then reflected in the fact that some statistical weight has to be discarded, which is the so-called truncation error. In many DMRG applications, it can be as small as $10^{-12}$, showing that the approximations made by DMRG are extremely light, which is the reason for the enormous success of the method. For the purpose of the tutorial it is important to know that the error in local quantities (energies, magnetizations, ...) is roughly proportional to (but usually quite a bit larger than) the truncation error, provided that the number of sweeps is large enough.
@@ -141,7 +141,7 @@ Consider chains of length $L=32,64,96,128$. Both for spin-1/2 and spin-1, set up
 
 1. For each system size and spin magnitude, try to establish the connection between the accuracy of the total energy and the truncation error by plotting total energy vs. truncation error.
 
-2. Observe how the convergence in $D$ deteriorates with system size for spin-1/2 and spin-1. Apart from a global factor of order of the length, do you see a difference between the convergence behaviour in the two cases? *Hint:* What you should see is, that but for the global factor, the convergence for large system sizes is only weakly dependent of length for the spin-1 chain, but much more strongly dependent for the spin-1/2 chain. This is because the spin-1 chain physics is dominated by segments of length of the correlation length, whereas for the spin-1/2 chain there is no finite length scale because of criticality.
+2. Observe how the convergence in $D$ deteriorates with system size for spin-1/2 and spin-1. Apart from a global factor of order of the length, do you see a difference between the convergence behavior in the two cases? *Hint:* What you should see is, that but for the global factor, the convergence for large system sizes is only weakly dependent of length for the spin-1 chain, but much more strongly dependent for the spin-1/2 chain. This is because the spin-1 chain physics is dominated by segments of length of the correlation length, whereas for the spin-1/2 chain there is no finite length scale because of criticality.
 
 3. Try to extrapolate ground state energies for each chain length to the $D\rightarrow\infty$ limit.
 
@@ -438,7 +438,7 @@ The correct way is to eliminate the effect of the open boundary conditions by co
 
 1. Calculate the ground state energy of two chains of length $L$ and $L+2$, again for the lengths already mentioned above, and calculate $e_0/J = (E_0(L+2) - E_0 (L))/2$ as the energy per bond. What do the results look like now?
 
-2. The less costly and usual way would be to use correlators (as discussed further below, so we postpone this exercise until then) between neighbouring sites and use
+2. The less costly and usual way would be to use correlators (as discussed further below, so we postpone this exercise until then) between neighboring sites and use
 $$
 e_0/J = \frac{1}{2} (\langle S^+_i S^-_{i+1}\rangle  + \langle S^-_i S^+_{i+1}\rangle ) + \langle S^z_i S^z_{i+1} \rangle 
 $$

--- a/content/en/tutorials/dmrg/dmrg02.md
+++ b/content/en/tutorials/dmrg/dmrg02.md
@@ -173,7 +173,7 @@ print('Gap:', energies[1]-energies[0])
 
 ### Extrapolating The Gap To The Thermodynamic Limit
 
-In a first attempt, fix $D=50,100,150$ and calculate the gap for lengths $L=32,64,96,128$. For fixed $D$, plot the gap versus $1/L$. What you should see is that for small $D$, the results will not lie on a straight line passing through 0, but they will curve up from it. This behaviour gets better when $D$ gets larger. Discuss why this might be.
+In a first attempt, fix $D=50,100,150$ and calculate the gap for lengths $L=32,64,96,128$. For fixed $D$, plot the gap versus $1/L$. What you should see is that for small $D$, the results will not lie on a straight line passing through 0, but they will curve up from it. This behavior gets better when $D$ gets larger. Discuss why this might be.
 
 In a second, more meaningful attempt, fix the lengths $L=32,64,96,128$ and vary $D=50,100,150,200$ in order to extrapolate the gap for each fixed length in $D$ (or, as explained above, the truncation error). What does the plot of the gap versus $1/L$ look like now?
 
@@ -190,11 +190,11 @@ Assume you have $\Delta (L)$ with machine precision, either by a suitable extrap
 
 As the effects of the open ends will decrease as $1/L$, it always makes sense to first plot the gaps $\Delta (L)$ versus $1/L$, as was already done in the spin-1/2 case. Produce such a plot.
 
-What you see is a curve that is quite straight for small L and then starts bending upward. What gap would you obtain if you extrapolate the linear part of the curve naively? (This question is relevant for situations where the correlation length of the chain is so long that it becomes hard to see the asymptotic behaviour on reachable length scales.) Is it over- or underestimated?
+What you see is a curve that is quite straight for small L and then starts bending upward. What gap would you obtain if you extrapolate the linear part of the curve naively? (This question is relevant for situations where the correlation length of the chain is so long that it becomes hard to see the asymptotic behavior on reachable length scales.) Is it over- or underestimated?
 
 What gap do you read off if you take the longest chain you have? Is it over- or underestimated?
 
-The ideal would be to have an idea of what the asymptotic behaviour (the curved part for long lengths) is like analytically to extrapolate. Do a plot of the gap as $\Delta (L)$ versus $1/L^2$. What does the curve now look like for big lengths? Extrapolate the gap.
+The ideal would be to have an idea of what the asymptotic behavior (the curved part for long lengths) is like analytically to extrapolate. Do a plot of the gap as $\Delta (L)$ versus $1/L^2$. What does the curve now look like for big lengths? Extrapolate the gap.
 
 The last plot was in fact motivated by the following argument: from Haldane's analysis of the spin-1 chain by the nonlinear sigma model, one expects that the lowest lying excitations (which for periodic boundary conditions can be labeled by a momentum $k$) are around $k=\pi$ and have an energy
 
@@ -210,4 +210,4 @@ $$
 
 and indicates that in the asymptotic limit the convergence should essentially be as $1/L^2$. How close do you get to the result $\Delta/J=0.41052$?
 
-For those that also did the gap between the ground states of magnetisation sectors 0 and 1, show that the gap you get there is essentially zero. All others, take this result for granted and start worrying: why is the finite gap the right one and the vanishing gap the wrong one? Is this a physics lottery? In fact, there is a very good reason why the spin-1 chain shows this peculiar behaviour for open boundary conditions that can be found analytically; but even if we were not so fortunate as to know it, we could detect the problem right away! This can be done by the observation of local observables.
+For those that also did the gap between the ground states of magnetization sectors 0 and 1, show that the gap you get there is essentially zero. All others, take this result for granted and start worrying: why is the finite gap the right one and the vanishing gap the wrong one? Is this a physics lottery? In fact, there is a very good reason why the spin-1 chain shows this peculiar behavior for open boundary conditions that can be found analytically; but even if we were not so fortunate as to know it, we could detect the problem right away! This can be done by the observation of local observables.

--- a/content/en/tutorials/dmrg/dmrg03.md
+++ b/content/en/tutorials/dmrg/dmrg03.md
@@ -9,9 +9,9 @@ We consider observables that are linked to one specific site to be local observa
 
 ## Excitations in the Spin-1 Chain
 
-Take a chain of length $L=96$ and $D=200$. Calculate the local magnetization $\langle S^z_i \rangle$  and plot it versus the site $i$ for the ground states in the magnetisation sectors 0, 1, and 2.
+Take a chain of length $L=96$ and $D=200$. Calculate the local magnetization $\langle S^z_i \rangle$  and plot it versus the site $i$ for the ground states in the magnetization sectors 0, 1, and 2.
 
-What you should obtain is an essentially flat curve for sector 0, a magnetisation which is essentially concentrated at the chain ends for sector 1, and a magnetisation which is both at the chain ends and in the bulk of the chain for sector 2. This means that the first excitation of the open chain is a boundary excitation, which would not exist on a closed system, and the second excitation of the open chain is a boundary plus a bulk excitation, which is the one we are interested in. For an as of now unknown reason, the energy of the first bulk excitation therefore has to be extracted from comparing sectors 1 and 2.
+What you should obtain is an essentially flat curve for sector 0, a magnetization which is essentially concentrated at the chain ends for sector 1, and a magnetization which is both at the chain ends and in the bulk of the chain for sector 2. This means that the first excitation of the open chain is a boundary excitation, which would not exist on a closed system, and the second excitation of the open chain is a boundary plus a bulk excitation, which is the one we are interested in. For an as of now unknown reason, the energy of the first bulk excitation therefore has to be extracted from comparing sectors 1 and 2.
 
 The moral of the story is that by looking at this local observable, we can distinguish boundary from bulk excitations in the spin-1 chain.
 
@@ -85,9 +85,9 @@ and plot them.
     plt.xlabel('site')
     plt.show()
 
-## Magnetisation in the Spin-1/2 Chain
+## Magnetization in the Spin-1/2 Chain
 
-Repeat a similar calculation for the spin-1/2 chain in the lowest magnetisation sectors. What do you observe here?
+Repeat a similar calculation for the spin-1/2 chain in the lowest magnetization sectors. What do you observe here?
 
 ### Using parameter files
 

--- a/content/en/tutorials/dmrg/dmrg04.md
+++ b/content/en/tutorials/dmrg/dmrg04.md
@@ -19,7 +19,7 @@ $$
 
 This gives the energy of each bond individually, but we are interested in the thermodynamic limit, where all bonds are on equal footing and hence should have the same energy unless there is some physical breaking of translational invariance.
 
-Obviously, the bonds that are closest to the thermodynamic limit behaviour are those in the chain center. So, the direct approach would be to calculate $e_0(L/2)$ and extrapolate it first in $D$ for fixed $L$ and then in $L$.
+Obviously, the bonds that are closest to the thermodynamic limit behavior are those in the chain center. So, the direct approach would be to calculate $e_0(L/2)$ and extrapolate it first in $D$ for fixed $L$ and then in $L$.
 
 Before you do this, however, plot for some values of $D$ and not too small $L e_0(i)$ versus $i$ (as a check of the program, you may also consider the three contributions individually before you do the sum. What relationship between them should exist?).
 
@@ -182,7 +182,7 @@ After running the simulation, correlations can be extracted and plotted in the s
 
 ### Sometimes There Is A Way Out
 
-In the special case of the spin-1 chain, we have a loophole for the calculation of the correlation length, which is related to the weird observation that the first excitation was not a bulk excitation. It can be shown that a good toy model for a spin-1 chain is given as follows: at each site of a spin-1, you put two spin-1/2, and construct the spin-1 states from the triplet states of the two spin-1/2 at each site. The ground state is then approximated quite well by a state where you link two spin-1/2 on *neighbouring* sites by a singlet state.
+In the special case of the spin-1 chain, we have a loophole for the calculation of the correlation length, which is related to the weird observation that the first excitation was not a bulk excitation. It can be shown that a good toy model for a spin-1 chain is given as follows: at each site of a spin-1, you put two spin-1/2, and construct the spin-1 states from the triplet states of the two spin-1/2 at each site. The ground state is then approximated quite well by a state where you link two spin-1/2 on *neighboring* sites by a singlet state.
 
 In this construction, for open boundary conditions (but not periodic ones), on the first and on the last site there will be two lonely spins-1/2 without partner. These two spins-1/2 can form 4 states among themselves, which in the toy model are degenerate: the ground state is four-fold degenerate. In the real spin-1 chain, this four-fold degeneracy (from one state of total spin 0 and three of total spin 1) is only achieved in the thermodynamic limit when the two spins are totally removed from each other. This is why there was no gap between magnetization sectors 0 and 1. The first bulk excitation needs magnetization 2.
 

--- a/content/en/tutorials/ed/_index.md
+++ b/content/en/tutorials/ed/_index.md
@@ -23,10 +23,10 @@ These tutorials introduce the custom measurements available on the computed eige
 ## Conformal Field Theory and Quantum Criticality
 
 At a quantum critical point, the finite-size spectrum of a 1D lattice model encodes the operator content of the underlying conformal field theory (CFT): energy gaps scale as $1/L$ with universal amplitudes set by the scaling dimensions of the CFT operators.
-These tutorials use `sparsediag` to extract that operator content directly from finite-size spectra, and use it to locate and characterise a quantum phase transition.
+These tutorials use `sparsediag` to extract that operator content directly from finite-size spectra, and use it to locate and characterize a quantum phase transition.
 
 - [ED-04 Conformal field theory description of 1D critical spectra](ed04) — computes the finite-size spectra of the critical transverse-field Ising chain and the critical Heisenberg chain, and matches the extracted scaling dimensions to the known CFT primary fields and their descendants.
-- [ED-05 Phase transition in a frustrated spin chain](ed05) — adds a next-nearest-neighbour coupling $J_2$ to the Heisenberg chain and locates the critical point separating the gapless and dimerized (Majumdar-Ghosh) phases by tracking level crossings and gaps in different symmetry sectors, then revisits the CFT content exactly at criticality.
+- [ED-05 Phase transition in a frustrated spin chain](ed05) — adds a next-nearest-neighbor coupling $J_2$ to the Heisenberg chain and locates the critical point separating the gapless and dimerized (Majumdar-Ghosh) phases by tracking level crossings and gaps in different symmetry sectors, then revisits the CFT content exactly at criticality.
 
 ## Full Diagonalization (`fulldiag`)
 

--- a/content/en/tutorials/ed/ed01.md
+++ b/content/en/tutorials/ed/ed01.md
@@ -15,7 +15,7 @@ $$
 H = J \sum_{\langle i,j \rangle} \mathbf{S}_i \cdot \mathbf{S}_j , \qquad J>0 ,
 $$
 
-where the sum runs over nearest-neighbour bonds on a periodic chain. This model is the paradigmatic example of an integer-spin antiferromagnet: Haldane predicted, and numerics have since confirmed, that it has a unique, gapped ground state with exponentially decaying spin correlations and short-range antiferromagnetic order peaked at momentum $q=\pi$ ([F.D.M. Haldane, Phys. Rev. Lett. 50, 1153 (1983)](https://doi.org/10.1103/PhysRevLett.50.1153)). Exact diagonalization gives us direct access to the ground-state wavefunction of a finite chain, from which we can compute any correlation function or structure factor exactly — this tutorial shows how to request such measurements from `sparsediag`. The finite-size gap itself is the subject of the next tutorial, [ED-02](../ed02).
+where the sum runs over nearest-neighbor bonds on a periodic chain. This model is the paradigmatic example of an integer-spin antiferromagnet: Haldane predicted, and numerics have since confirmed, that it has a unique, gapped ground state with exponentially decaying spin correlations and short-range antiferromagnetic order peaked at momentum $q=\pi$ ([F.D.M. Haldane, Phys. Rev. Lett. 50, 1153 (1983)](https://doi.org/10.1103/PhysRevLett.50.1153)). Exact diagonalization gives us direct access to the ground-state wavefunction of a finite chain, from which we can compute any correlation function or structure factor exactly — this tutorial shows how to request such measurements from `sparsediag`. The finite-size gap itself is the subject of the next tutorial, [ED-02](../ed02).
 
 ### Parameters
 
@@ -24,7 +24,7 @@ where the sum runs over nearest-neighbour bonds on a periodic chain. This model 
 | `LATTICE` | built-in periodic 1D lattice | `chain lattice` |
 | `MODEL` | quantum spin model | `spin` |
 | `local_S` | spin quantum number per site | 1 |
-| `J` | nearest-neighbour Heisenberg coupling | 1 |
+| `J` | nearest-neighbor Heisenberg coupling | 1 |
 | `L` | number of sites | 4 |
 | `CONSERVED_QUANTUMNUMBERS` | symmetries used to block-diagonalize the Hamiltonian | `Sz` |
 | `MEASURE_CORRELATIONS[...]` | requests $\langle S^z_iS^z_j\rangle$ and $\langle S^+_iS^-_j\rangle$ on every computed eigenstate | see below |
@@ -32,7 +32,7 @@ where the sum runs over nearest-neighbour bonds on a periodic chain. This model 
 
 ### Lattice
 
-The `chain lattice` is one of the built-in geometries of the [ALPS lattice library](../../../documentation/intro/latticehowtos); it places `L` sites on a ring connected by periodic nearest-neighbour bonds of strength `J`:
+The `chain lattice` is one of the built-in geometries of the [ALPS lattice library](../../../documentation/intro/latticehowtos); it places `L` sites on a ring connected by periodic nearest-neighbor bonds of strength `J`:
 
 ```
       J     J     J
@@ -141,7 +141,7 @@ for sector in data[0]:
 
 ## Summary
 
-For the L=4 S=1 chain, the ground state lies in the $(S_z,P)=(0,0)$ sector and shows short-ranged antiferromagnetic diagonal correlations that alternate in sign with distance and decay with separation, and a static structure factor that is strongly peaked at $q=\pi$ (value 2, versus $\approx 0.33$ at the neighbouring momenta) — the expected signature of the short-range Néel-like order of a gapped Haldane chain, already visible on this very small system.
+For the L=4 S=1 chain, the ground state lies in the $(S_z,P)=(0,0)$ sector and shows short-ranged antiferromagnetic diagonal correlations that alternate in sign with distance and decay with separation, and a static structure factor that is strongly peaked at $q=\pi$ (value 2, versus $\approx 0.33$ at the neighboring momenta) — the expected signature of the short-range Néel-like order of a gapped Haldane chain, already visible on this very small system.
 
 ## Questions
 

--- a/content/en/tutorials/ed/ed02.md
+++ b/content/en/tutorials/ed/ed02.md
@@ -25,7 +25,7 @@ on a periodic chain of $L$ sites, differing only in the local spin length $S$.
 | `LATTICE` | periodic chain | `chain lattice` |
 | `MODEL` | quantum spin model | `spin` |
 | `local_S` | spin quantum number per site | 1 (`parm2a`) or 1/2 (`parm2b`) |
-| `J` | nearest-neighbour Heisenberg coupling | 1 |
+| `J` | nearest-neighbor Heisenberg coupling | 1 |
 | `L` | chain length | 4, 6, 8, 10 |
 | `CONSERVED_QUANTUMNUMBERS` | symmetry used to block-diagonalize $H$ | `Sz` |
 | `Sz_total` | restricts the diagonalization to a single $S_z$ sector | 0 (singlet sector) and 1 (triplet sector) |
@@ -185,11 +185,11 @@ The table below lists the exact triplet gap $\Delta(L)=E_0(S_z=1)-E_0(S_z=0)$ ob
 | 8  | 0.125 | 0.5936 | 0.5227 |
 | 10 | 0.100 | 0.5248 | 0.4232 |
 
-The S=1 gap is levelling off and extrapolates (e.g. by a quadratic fit in $1/L$) to a finite value close to the literature estimate for the Haldane gap, $\Delta_\infty \approx 0.41\,J$, while the S=1/2 gap keeps decreasing and is consistent with extrapolating to zero — the hallmark of a gapless chain.
+The S=1 gap is leveling off and extrapolates (e.g. by a quadratic fit in $1/L$) to a finite value close to the literature estimate for the Haldane gap, $\Delta_\infty \approx 0.41\,J$, while the S=1/2 gap keeps decreasing and is consistent with extrapolating to zero — the hallmark of a gapless chain.
 
 ## Summary
 
-For the same nearest-neighbour antiferromagnetic Heisenberg coupling, the S=1 chain extrapolates to a finite excitation gap while the S=1/2 chain extrapolates to zero, directly confirming the Haldane conjecture on chains small enough to diagonalize exactly.
+For the same nearest-neighbor antiferromagnetic Heisenberg coupling, the S=1 chain extrapolates to a finite excitation gap while the S=1/2 chain extrapolates to zero, directly confirming the Haldane conjecture on chains small enough to diagonalize exactly.
 
 ## Questions
 

--- a/content/en/tutorials/ed/ed04.md
+++ b/content/en/tutorials/ed/ed04.md
@@ -5,7 +5,7 @@ math: true
 toc: true
 ---
 
-In this tutorial, we will look at critical spin chains and make a connection to their description in terms of conformal field theory. At a continuous quantum phase transition, a spin chain becomes scale-invariant and its long-distance physics is described by a $(1+1)$-dimensional conformal field theory (CFT). A finite chain can never be truly at the transition, but it inherits a universal fingerprint of it: the low-lying finite-size spectrum organises itself into towers labelled by the scaling dimensions $\Delta$ of the CFT's primary operators and their descendants, with level spacings that vanish as $1/L$. Exact diagonalization is the ideal tool to see this directly, since it gives us the complete low-energy spectrum, including its momenta, for chains of a few tens of sites — enough to already resolve the universal operator content.
+In this tutorial, we will look at critical spin chains and make a connection to their description in terms of conformal field theory. At a continuous quantum phase transition, a spin chain becomes scale-invariant and its long-distance physics is described by a $(1+1)$-dimensional conformal field theory (CFT). A finite chain can never be truly at the transition, but it inherits a universal fingerprint of it: the low-lying finite-size spectrum organizes itself into towers labeled by the scaling dimensions $\Delta$ of the CFT's primary operators and their descendants, with level spacings that vanish as $1/L$. Exact diagonalization is the ideal tool to see this directly, since it gives us the complete low-energy spectrum, including its momenta, for chains of a few tens of sites — enough to already resolve the universal operator content.
 
 ## Ising chain
 
@@ -15,7 +15,7 @@ $$
 H=J_{z} \sum_{\langle i,j \rangle} S^i_z S^j_z + \Gamma \sum_i S^i_x
 $$
 
-Here, the first sum runs over pairs of nearest neighbours. $\Gamma$ is referred to as transverse field; the system becomes critical for $\Gamma/J=\tfrac{1}{2}$. For $\Gamma=0$, the ground state is antiferromagnetic for $J\gt 0$ and ferromagnetic for $J \lt 0$. The system is exactly solvable ([P. Pfeuty, Annals of Physics 57, 79 (1970)](https://doi.org/10.1016/0003-4916(70)90270-8)).
+Here, the first sum runs over pairs of nearest neighbors. $\Gamma$ is referred to as transverse field; the system becomes critical for $\Gamma/J=\tfrac{1}{2}$. For $\Gamma=0$, the ground state is antiferromagnetic for $J\gt 0$ and ferromagnetic for $J \lt 0$. The system is exactly solvable ([P. Pfeuty, Annals of Physics 57, 79 (1970)](https://doi.org/10.1016/0003-4916(70)90270-8)).
 
 In the above equation, $\Delta$ refers to the scaling dimension of that field. The scaling fields occur in groups: the lowest one, referred to as primary field, comes with an infinite number of descendants with scaling dimension $\Delta + m$, $m \in \lbrace 1, 2, 3, ... \rbrace$.
 
@@ -263,7 +263,7 @@ Diagonalizing independently, the $S_z=0$-sector levels rescaled by $(E-E_0)/\Del
 | 14 | 0.3071 | 0 | 0.500 (def.) | 0.839 | 1.148, 1.148 |
 | 16 | 0.2702 | 0 | 0.500 (def.) | 0.825 | 1.145, 1.145 |
 
-The third level, expected to converge to the descendant at scaling dimension 1, instead drifts slowly *away* from it, from 0.880 ($L=10$) to 0.825 ($L=16$), rather than approaching it monotonically the way the Ising levels did. This sluggish, non-monotonic behaviour is the practical symptom of the marginally irrelevant operator mentioned above, whose log-suppressed corrections dominate the size dependence at accessible $L$ and only fade at astronomically larger sizes. [ED-05](../ed05) shows how tuning to a nearby frustrated point removes this marginal operator and restores fast, textbook $1/L$ convergence.
+The third level, expected to converge to the descendant at scaling dimension 1, instead drifts slowly *away* from it, from 0.880 ($L=10$) to 0.825 ($L=16$), rather than approaching it monotonically the way the Ising levels did. This sluggish, non-monotonic behavior is the practical symptom of the marginally irrelevant operator mentioned above, whose log-suppressed corrections dominate the size dependence at accessible $L$ and only fade at astronomically larger sizes. [ED-05](../ed05) shows how tuning to a nearby frustrated point removes this marginal operator and restores fast, textbook $1/L$ convergence.
 
 ## Summary
 
@@ -273,4 +273,4 @@ Both the exactly solvable transverse-field Ising chain and the harder-to-converg
 
 - For the Ising chain, why do the rescaled energies come in degenerate pairs starting from the third level (e.g. two states near 1.107)? (Hint: think about the momentum quantum number of the corresponding descendant operators.)
 - Repeat the Ising CFT analysis for a value of $\Gamma$ away from the critical point (e.g. $\Gamma=0.2$ or $\Gamma=1.0$). Does the rescaled spectrum still look CFT-like as $L$ increases?
-- For the Heisenberg chain, the third rescaled level moves *away* from its CFT target as $L$ grows from 10 to 16, instead of settling towards it. Compute a couple of further sizes (e.g. $L=18,20$) if you can — does the drift eventually turn around, and how would you distinguish "very slow monotonic convergence" from "genuinely non-monotonic" behaviour with only a handful of accessible system sizes?
+- For the Heisenberg chain, the third rescaled level moves *away* from its CFT target as $L$ grows from 10 to 16, instead of settling towards it. Compute a couple of further sizes (e.g. $L=18,20$) if you can — does the drift eventually turn around, and how would you distinguish "very slow monotonic convergence" from "genuinely non-monotonic" behavior with only a handful of accessible system sizes?

--- a/content/en/tutorials/ed/ed05.md
+++ b/content/en/tutorials/ed/ed05.md
@@ -5,17 +5,17 @@ math: true
 toc: true
 ---
 
-## Critical point of the Heisenberg chain with next-nearest-neighbour interaction
+## Critical point of the Heisenberg chain with next-nearest-neighbor interaction
 
-In this tutorial, we will follow up on the last part of the ED-04 tutorial, where the Heisenberg chain was considered. We will add a next-nearest-neighbour coupling term to the Hamiltonian,
+In this tutorial, we will follow up on the last part of the ED-04 tutorial, where the Heisenberg chain was considered. We will add a next-nearest-neighbor coupling term to the Hamiltonian,
 
 $$
 H = J_1 \sum_{\langle i,j \rangle} \mathbf{S}_i \cdot \mathbf{S}_j \; + \; J_2 \sum_{\langle\langle i,j \rangle\rangle} \mathbf{S}_i \cdot \mathbf{S}_j ,
 $$
 
-where the first sum runs over nearest-neighbour bonds and the second over next-nearest-neighbour bonds on the same periodic chain. This is the celebrated $J_1$–$J_2$ (or Majumdar-Ghosh) chain.
+where the first sum runs over nearest-neighbor bonds and the second over next-nearest-neighbor bonds on the same periodic chain. This is the celebrated $J_1$–$J_2$ (or Majumdar-Ghosh) chain.
 
-In the limit of $J_2 = 0$, this model reduces to the critical Heisenberg chain, which is solvable by Bethe ansatz. At $J_2/J_1=0.5$, the model is also exactly solvable: it sits at the Majumdar-Ghosh point, where the ground state is an exact product of nearest-neighbour singlets ([C.K. Majumdar and D.K. Ghosh, J. Math. Phys. 10, 1388 (1969)](https://doi.org/10.1063/1.1664978)),
+In the limit of $J_2 = 0$, this model reduces to the critical Heisenberg chain, which is solvable by Bethe ansatz. At $J_2/J_1=0.5$, the model is also exactly solvable: it sits at the Majumdar-Ghosh point, where the ground state is an exact product of nearest-neighbor singlets ([C.K. Majumdar and D.K. Ghosh, J. Math. Phys. 10, 1388 (1969)](https://doi.org/10.1063/1.1664978)),
 $$
 |\Psi\rangle = \left(|\uparrow\rangle_1 |\downarrow\rangle_2 - |\downarrow\rangle_1 |\uparrow\rangle_2\right) (|\uparrow\rangle_3 |\downarrow\rangle_4 - |\downarrow\rangle_3 |\uparrow\rangle_4) (|\uparrow\rangle_5 |\downarrow\rangle_6 - |\downarrow\rangle_5 |\uparrow\rangle_6)
 $$
@@ -31,22 +31,22 @@ In the first part of this tutorial, we will locate the position of the critical 
 | `LATTICE` | periodic chain with NN and NNN bonds | `nnn chain lattice` |
 | `MODEL` | quantum spin model | `spin` |
 | `local_S` | spin quantum number per site | 1/2 |
-| `J` | nearest-neighbour coupling $J_1$ | 1 |
-| `J1` | next-nearest-neighbour coupling $J_2$ (note: ALPS's `nnn chain lattice` names this bond parameter `J1`, distinct from the $J_2$ used in the Hamiltonian above) | swept over $[0,0.5]$ (Part 1) or fixed at 0.25 (Part 2) |
+| `J` | nearest-neighbor coupling $J_1$ | 1 |
+| `J1` | next-nearest-neighbor coupling $J_2$ (note: ALPS's `nnn chain lattice` names this bond parameter `J1`, distinct from the $J_2$ used in the Hamiltonian above) | swept over $[0,0.5]$ (Part 1) or fixed at 0.25 (Part 2) |
 | `CONSERVED_QUANTUMNUMBERS`, `Sz_total` | resolve the singlet ($S_z=0$) and triplet ($S_z=1$) sectors separately | `Sz`, 0 and 1 |
 | `NUMBER_EIGENVALUES` | eigenstates requested from `sparsediag` | 2 (Part 1) or 5 (Part 2) |
 | `L` | chain length | 6, 8 (Part 1) or 10, 12 (Part 2) |
 
 ### Lattice
 
-The `nnn chain lattice` extends the periodic chain with a second set of bonds connecting each site to its next-nearest neighbour:
+The `nnn chain lattice` extends the periodic chain with a second set of bonds connecting each site to its next-nearest neighbor:
 
 ```
         J          J          J
    o---------o---------o---------o---(periodic)
    0         1         2         3
     \___________________________/
-        J1 (=J2)   next-nearest-neighbour bonds
+        J1 (=J2)   next-nearest-neighbor bonds
 ```
 
 This built-in lattice is documented, along with the rest of the [ALPS lattice library](../../../documentation/intro/latticehowtos), as an extension of the plain `chain lattice` used in the previous tutorials.
@@ -253,7 +253,7 @@ plt.show()
 
 ### Output data
 
-Diagonalizing the sectors independently gives the following singlet and triplet gaps as a function of $J_2/J_1$ (here labelled `J1` in the ALPS parameter, as noted above):
+Diagonalizing the sectors independently gives the following singlet and triplet gaps as a function of $J_2/J_1$ (here labeled `J1` in the ALPS parameter, as noted above):
 
 | $L$ | $J_2/J_1$ | singlet gap $/J_1$ | triplet gap $/J_1$ |
 |---|---|---|---|
@@ -272,7 +272,7 @@ Diagonalizing the sectors independently gives the following singlet and triplet 
 
 For both system sizes the singlet gap (initially the larger of the two, since $J_2=0$ is gapless with the lowest excitation approaching zero only as $L\to\infty$) drops below the triplet gap between $J_2/J_1=0.2$ and $0.3$, crossing almost exactly at $J_2/J_1\approx0.25$ — already close to the accepted thermodynamic-limit value $J_2/J_1\approx0.2411$ even at these small sizes. This level crossing is the finite-size signature of the transition into the dimerized phase; note also that the singlet gap vanishes exactly at $J_2/J_1=0.5$, the Majumdar-Ghosh point, consistent with its exactly two-fold degenerate ground state.
 
-## Heisenberg chain with next-nearest neighbour coupling: CFT assignments
+## Heisenberg chain with next-nearest neighbor coupling: CFT assignments
 
 The finite-size corrections can be significantly reduced by tuning to a critical point in a frustrated J1-J2 chain. Despite the different couplings, this model can be shown to have the same continuum critical field theory and we can therefore extract the scaling dimensions in this limit. For a detailed discussion of this point, take a look at the reference [I. Affleck, D. Gepner, H.J. Schulz and T. Ziman, J. Phys. A: Math. Gen. 22, 511 (1989)](https://doi.org/10.1088/0305-4470/22/5/015).
 

--- a/content/en/tutorials/ed/ed06.md
+++ b/content/en/tutorials/ed/ed06.md
@@ -24,7 +24,7 @@ on a periodic chain, whose finite-chain thermodynamics were first studied system
 | `LATTICE` | periodic chain | `chain lattice` |
 | `MODEL` | quantum spin model | `spin` |
 | `local_S` | spin quantum number per site | 1 |
-| `J` | nearest-neighbour coupling | 1 |
+| `J` | nearest-neighbor coupling | 1 |
 | `L` | chain length | 8 |
 | `CONSERVED_QUANTUMNUMBERS` | symmetry used to block-diagonalize $H$ | `Sz` |
 
@@ -147,7 +147,7 @@ Diagonalizing the same Hamiltonian independently gives the following per-site th
 | 2.0 | -0.653 | 0.278 | 0.1639 |
 | 5.0 | -0.274 | 0.055 | 0.1010 |
 
-The specific heat has a broad maximum around $T\approx J$, while the susceptibility peaks near $T\approx1$–$1.5\,J$ and then drops sharply towards $T=0$ — the finite-size remnant of the exponentially activated behaviour $\chi\sim e^{-\Delta/T}$ expected from the Haldane gap $\Delta\approx0.41\,J$ computed in [ED-02](../ed02).
+The specific heat has a broad maximum around $T\approx J$, while the susceptibility peaks near $T\approx1$–$1.5\,J$ and then drops sharply towards $T=0$ — the finite-size remnant of the exponentially activated behavior $\chi\sim e^{-\Delta/T}$ expected from the Haldane gap $\Delta\approx0.41\,J$ computed in [ED-02](../ed02).
 
 #### Exercises
 

--- a/content/en/tutorials/jupyter/ed/isingTransverseField.md
+++ b/content/en/tutorials/jupyter/ed/isingTransverseField.md
@@ -18,7 +18,7 @@ $$
 H=J_{z} \sum_{\langle i,j \rangle} S^i_z S^j_z + \Gamma \sum_i S^i_x
 $$
 
-Here, the first sum runs over pairs of nearest neighbours. $\Gamma$ is referred to as transverse field; the system becomes critical for $\Gamma/J=\frac{1}{2}$. For $\Gamma=0$, the ground state is antiferromagnetic for $J\gt 0$ and ferromagnetic for $J \lt 0$. The system is exactly solvable ([P. Pfeuty, Annals of Physics: 57, 79-90 (1970)](https://www.sciencedirect.com/science/article/abs/pii/0003491670902708?via%3Dihub)).
+Here, the first sum runs over pairs of nearest neighbors. $\Gamma$ is referred to as transverse field; the system becomes critical for $\Gamma/J=\frac{1}{2}$. For $\Gamma=0$, the ground state is antiferromagnetic for $J\gt 0$ and ferromagnetic for $J \lt 0$. The system is exactly solvable ([P. Pfeuty, Annals of Physics: 57, 79-90 (1970)](https://www.sciencedirect.com/science/article/abs/pii/0003491670902708?via%3Dihub)).
 
 In the above equation, $\Delta$ refers to the scaling dimension of that field. The scaling fields occur in groups: the lowest one, referred to as primary field, comes with an infinite number of descendants with scaling dimension $\Delta + m$, $m \in \lbrace 1, 2, 3, ... \rbrace$.
 

--- a/content/en/tutorials/jupyter/ed/spectra1dsystems.md
+++ b/content/en/tutorials/jupyter/ed/spectra1dsystems.md
@@ -16,7 +16,7 @@ In this tutorial we will calculate the energy spectra of the quantum Heisenberg 
 
 The Hamiltonian for the spin-1/2 Heisenberg chain is given by 
 $$H = J\sum_{\langle i,j \rangle} \mathbf{S}^i \cdot \mathbf{S}^j$$,
-where $J>0$ for antiferromagnetic interactions between two nearest-neighbour spins $\mathbf{S}^i$ and $\mathbf{S}^j$, and the spin-spin interaction consists of three components, i.e., 
+where $J>0$ for antiferromagnetic interactions between two nearest-neighbor spins $\mathbf{S}^i$ and $\mathbf{S}^j$, and the spin-spin interaction consists of three components, i.e., 
 $$\mathbf{S}^i \cdot \mathbf{S}^j=S^i_xS^j_x+S^i_yS^j_y+S^i_zS^j_z$$.
 
 The basis states are usually chosen to be the eigen states of $S_z$ operator. For a spin-1/2 system, there are two basis states for each lattice site, $|-1/2\rangle$ and $|+1/2\rangle$. The application of $S_x$ and $S_y$ operators on these basis states can be expressed in terms of raising $S^{\dagger}$ and lowering $S^{-}$ operators:
@@ -118,7 +118,7 @@ Below is the energy spectrum for a 1D Heisenberg chain:
 
 The Hamiltonian for the two-leg spin-1/2 Heisenberg chain is given by 
 $$H = J_0\sum_{\langle \alpha i,\alpha j \rangle} \mathbf{S}^{\alpha i} \cdot \mathbf{S}^{\alpha j} + J_1\sum_{\langle 1 i,2 i \rangle} \mathbf{S}^{1 i} \cdot \mathbf{S}^{2 i}$$,
-where, $\alpha=1,2$ denotes the two legs/chains, $i,j=1,2,\cdots,L$ label lattice sites within a chain, $J_0>0$ is the intra-chain antiferromagnetic interactions between two nearest-neighbour spins $\mathbf{S}^{\alpha i}$ and $\mathbf{S}^{\alpha j}$ in the same chain, and $J_1>0$ is the inter-chain spin-spin coupling between $\mathbf{S}^{1 i}$ from the first leg and $\mathbf{S}^{2 i}$ from the second leg with $i=1,2,\cdots,L$. 
+where, $\alpha=1,2$ denotes the two legs/chains, $i,j=1,2,\cdots,L$ label lattice sites within a chain, $J_0>0$ is the intra-chain antiferromagnetic interactions between two nearest-neighbor spins $\mathbf{S}^{\alpha i}$ and $\mathbf{S}^{\alpha j}$ in the same chain, and $J_1>0$ is the inter-chain spin-spin coupling between $\mathbf{S}^{1 i}$ from the first leg and $\mathbf{S}^{2 i}$ from the second leg with $i=1,2,\cdots,L$. 
 
 #### Simulation
 
@@ -207,7 +207,7 @@ Below shows the energy spectrum for a Heisenberg ladder:
 
 For our third simulation, we start with the same Hamiltonian as in the previous case
 $$H = J_0\sum_{\langle \alpha i,\alpha j \rangle} \mathbf{S}^{\alpha i} \cdot \mathbf{S}^{\alpha j} + J_1\sum_{\langle 1 i,2 i \rangle} \mathbf{S}^{1 i} \cdot \mathbf{S}^{2 i}$$,
-where, $\alpha=1,2$ denotes the two legs/chains, $i,j=1,2,\cdots,L$ label lattice sites within a chain, we set $J_0=0$, i.e., no intra-chain interactions between two nearest-neighbour spins, and $J_1=1$ is the inter-chain spin-spin coupling between $\mathbf{S}^{1 i}$ and $\mathbf{S}^{2 i}$ with $i=1,2,\cdots,L$. The system then becomes $L$ isolated dimers. 
+where, $\alpha=1,2$ denotes the two legs/chains, $i,j=1,2,\cdots,L$ label lattice sites within a chain, we set $J_0=0$, i.e., no intra-chain interactions between two nearest-neighbor spins, and $J_1=1$ is the inter-chain spin-spin coupling between $\mathbf{S}^{1 i}$ and $\mathbf{S}^{2 i}$ with $i=1,2,\cdots,L$. The system then becomes $L$ isolated dimers. 
 
 #### Simulation
 

--- a/content/en/tutorials/jupyter/ed/spinGapSpinOneHeisenbergChain.md
+++ b/content/en/tutorials/jupyter/ed/spinGapSpinOneHeisenbergChain.md
@@ -12,7 +12,7 @@ In this tutorial we will learn how to use the sparse diagonalization program (La
 
 The Hamiltonian for the spin-1 Heisenberg chain is given by 
 $$H = J\sum_{\langle i,j \rangle} \mathbf{S}^i \cdot \mathbf{S}^j$$,
-where $J>0$ for antiferromagnetic interactions between two nearest-neighbour spins $\mathbf{S}^i$ and $\mathbf{S}^j$, and the spin-spin interaction consists of three components, i.e., 
+where $J>0$ for antiferromagnetic interactions between two nearest-neighbor spins $\mathbf{S}^i$ and $\mathbf{S}^j$, and the spin-spin interaction consists of three components, i.e., 
 $$\mathbf{S}^i \cdot \mathbf{S}^j=S^i_xS^j_x+S^i_yS^j_y+S^i_zS^j_z$$.
 
 The basis states are usually chosen to be the eigen states of $S_z$ operator. For a spin-1 system, there are three basis states for each lattice site, $|-1\rangle$, $|0\rangle$, and $|+1\rangle$. The application of $S_x$ and $S_y$ operators on these basis states can be expressed in terms of raising $S^{\dagger}$ and lowering $S^{-}$ operators:

--- a/content/en/tutorials/lm/lm02.md
+++ b/content/en/tutorials/lm/lm02.md
@@ -655,7 +655,7 @@ Expected output (L=6, open chain, $t=1$, $N_{\max}=3$, $N=6$):
 
 ### Summary
 
-The excitation gap within the unit-filled sector grows rapidly with $U$: for $U = 0$ the bosons are superfluid and the gap is set by kinetic energy alone ($\approx 0.71\,t$); by $U = 10\,t$ on-site repulsion has made any particle-hole excitation extremely costly ($\approx 6.3\,t$), signalling deep Mott-insulator physics.
+The excitation gap within the unit-filled sector grows rapidly with $U$: for $U = 0$ the bosons are superfluid and the gap is set by kinetic energy alone ($\approx 0.71\,t$); by $U = 10\,t$ on-site repulsion has made any particle-hole excitation extremely costly ($\approx 6.3\,t$), signaling deep Mott-insulator physics.
 To measure the true **single-particle gap** $\Delta = E_0(N+1) + E_0(N-1) - 2E_0(N)$ (which vanishes in the superfluid and opens in the Mott phase), add tasks with `N_total=5` and `N_total=7` (see extension question 4).
 
 ---

--- a/content/en/tutorials/mcs/_index.md
+++ b/content/en/tutorials/mcs/_index.md
@@ -15,7 +15,7 @@ The tutorials progress from fundamental diagnostics such as autocorrelation time
 ## Choosing a Code
 
 Before starting a simulation it is important to select the algorithm best suited to your model and observable.
-The guide below compares the four QMC representations available in ALPS — `looper`, `dirloop_sse`, `worm`, and `qwl` — and summarises their respective strengths and limitations.
+The guide below compares the four QMC representations available in ALPS — `looper`, `dirloop_sse`, `worm`, and `qwl` — and summarizes their respective strengths and limitations.
 
 - [Which code to choose for your simulation?](com)
 
@@ -33,7 +33,7 @@ The method is revisited later to study finite-size scaling and the second-order 
 
 The `looper` code implements the loop algorithm in an operator-loop representation and is most efficient for isotropic spin models without a magnetic field.
 The `dirloop_sse` code uses directed loops in the stochastic series expansion (SSE) representation; it handles models with anisotropy or an external magnetic field that break the spin-inversion symmetry required by `looper`.
-These tutorials cover susceptibilities of Heisenberg chains and ladders, magnetization curves in a field, and the identification of a quantum phase transition in a dimerised lattice.
+These tutorials cover susceptibilities of Heisenberg chains and ladders, magnetization curves in a field, and the identification of a quantum phase transition in a dimerized lattice.
 
 - [MC-02 Calculating magnetic susceptibilities by the classical MC and looper QMC codes](mc02)
 - [MC-03 Calculating magnetization curves by the directed loop QMC code](mc03)

--- a/content/en/tutorials/mcs/mc01a.md
+++ b/content/en/tutorials/mcs/mc01a.md
@@ -181,7 +181,7 @@ From the figure below, you can clearly see that the errors do not converge for l
 
 ## Cluster updates
 
-Near the critical temperature, the correlation length $\xi$ grows large and local updates become highly inefficient: each accepted move flips a single spin, so it takes $O(\xi^2)$ sweeps merely to decorrelate two neighbouring spins.
+Near the critical temperature, the correlation length $\xi$ grows large and local updates become highly inefficient: each accepted move flips a single spin, so it takes $O(\xi^2)$ sweeps merely to decorrelate two neighboring spins.
 This *critical slowing down* means the autocorrelation time diverges as
 $$\tau \sim L^z,$$
 where $z \approx 2$ for local updates but $z \approx 0.25$ for cluster algorithms such as Wolff or Swendsen–Wang.

--- a/content/en/tutorials/mcs/mc02.md
+++ b/content/en/tutorials/mcs/mc02.md
@@ -10,9 +10,9 @@ The magnetic susceptibility $\chi = \partial\langle M \rangle / \partial h \big|
 Its temperature dependence is a sensitive probe of the underlying spin correlations: a system of weakly interacting spins follows the Curie law $\chi \propto 1/T$, while interactions and quantum effects produce characteristic deviations.
 
 This tutorial calculates $\chi(T)$ for four systems — classical and quantum Heisenberg models on one-dimensional chains and two-leg ladders — and overlays the results on a single plot.
-The comparison highlights two key contrasts: how quantum fluctuations modify the classical picture, and how changing the lattice geometry from a chain to a ladder affects the low-temperature behaviour.
+The comparison highlights two key contrasts: how quantum fluctuations modify the classical picture, and how changing the lattice geometry from a chain to a ladder affects the low-temperature behavior.
 
-> **Sign convention.** The classical `spinmc` code and the quantum `looper` code both use the Hamiltonian $H = J \sum \langle i,j \rangle \vec{S}_i \cdot \vec{S}_j$, where $J < 0$ favours ferromagnetic alignment and $J > 0$ favours antiferromagnetic alignment. The classical simulations below use $J = -1$ (ferromagnet); the quantum simulations use $J = +1$ (antiferromagnet). Both choices produce a positive susceptibility that grows at low temperature, making the comparison of classical versus quantum behaviour straightforward.
+> **Sign convention.** The classical `spinmc` code and the quantum `looper` code both use the Hamiltonian $H = J \sum \langle i,j \rangle \vec{S}_i \cdot \vec{S}_j$, where $J < 0$ favors ferromagnetic alignment and $J > 0$ favors antiferromagnetic alignment. The classical simulations below use $J = -1$ (ferromagnet); the quantum simulations use $J = +1$ (antiferromagnet). Both choices produce a positive susceptibility that grows at low temperature, making the comparison of classical versus quantum behavior straightforward.
 
 ## Classical Heisenberg models
 
@@ -305,7 +305,7 @@ At low temperature the quantum ladder drops steeply due to its spin gap, while t
 
 ## Questions
 
-- At high temperature, do all four curves approach the same $\chi \propto 1/T$ Curie behaviour? What sets the prefactor?
+- At high temperature, do all four curves approach the same $\chi \propto 1/T$ Curie behavior? What sets the prefactor?
 - What is the most visible difference between the classical chain and the quantum chain at low temperature?
 - The quantum ladder susceptibility falls much faster than the classical ladder at low $T$. What physical mechanism causes this?
 - Try larger system sizes or different lattices (`"cubic lattice"`, `"triangular lattice"` — see `lattices.xml`). How do the results change?

--- a/content/en/tutorials/mcs/mc04.md
+++ b/content/en/tutorials/mcs/mc04.md
@@ -118,7 +118,7 @@ plt.title('Spin correlations, $4\\times 4$ Heisenberg model')
 plt.show()
 ```
 
-The correlations should alternate in sign with distance, with the nearest-neighbour value negative (antiferromagnetic) and its magnitude decreasing with $r$.
+The correlations should alternate in sign with distance, with the nearest-neighbor value negative (antiferromagnetic) and its magnitude decreasing with $r$.
 
 ### Plotting the structure factor
 

--- a/content/en/tutorials/mcs/mc06.md
+++ b/content/en/tutorials/mcs/mc06.md
@@ -97,7 +97,7 @@ The parameter file <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials
 The Python script is <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-06-qwl/tutorial6c.py" download>`tutorial6c.py`</a>.
 Run and evaluate exactly as for the chain above.
 
-The staggered structure factor $S(\pi,\pi,\pi)$ should start rising steeply near $T\approx 1$, signalling the onset of antiferromagnetic correlations.
+The staggered structure factor $S(\pi,\pi,\pi)$ should start rising steeply near $T\approx 1$, signaling the onset of antiferromagnetic correlations.
 The specific heat shows a corresponding peak and the entropy decreases rapidly in the same temperature range.
 
 ### Finite-size scaling analysis to determine the critical point

--- a/content/en/tutorials/mcs/mc07.md
+++ b/content/en/tutorials/mcs/mc07.md
@@ -11,7 +11,7 @@ No true phase transition can occur on a finite system, but finite-size simulatio
 
 Almost everything is known about the phase transition in the 2D Ising model since it is exactly solvable.
 Here we recover the location of the critical point and the critical exponents as if they were unknown, to illustrate the methods.
-Extracting precise estimates requires long simulations, so we start the fine-grid run in the background at the outset and analyse the coarse-grid run first.
+Extracting precise estimates requires long simulations, so we start the fine-grid run in the background at the outset and analyze the coarse-grid run first.
 
 ## Background simulations
 

--- a/content/en/tutorials/mcs/mc08.md
+++ b/content/en/tutorials/mcs/mc08.md
@@ -6,7 +6,7 @@ toc: true
 weight: 10
 ---
 
-The goal of this tutorial is to locate and characterise quantum phase transitions in a two-dimensional spin model using finite-size scaling of quantum Monte Carlo data.
+The goal of this tutorial is to locate and characterize quantum phase transitions in a two-dimensional spin model using finite-size scaling of quantum Monte Carlo data.
 Unlike classical phase transitions, quantum phase transitions occur at $T=0$ and are driven by quantum fluctuations rather than thermal ones.
 We will use the Binder cumulant and the spin stiffness to pin down the critical coupling, then extract the correlation-length exponent $\nu$, the anomalous dimension $\eta$, and the dynamical exponent $z$ — placing the transition in its universality class.
 The model turns out to have two quantum critical points, and we study both.
@@ -53,7 +53,7 @@ Run the first part of <a href="https://github.com/ALPSim/ALPS/blob/master/tutori
 
 We begin by considering the two simple limits: decoupled ladders ($J_2=0$) and the isotropic square lattice ($J_2=1$). The decoupled ladders have a ground state with short-range correlations and exhibit a finite spin gap: this is a spin liquid phase. The square lattice, by contrast, displays long-range order with a finite staggered magnetization: this is an antiferromagnetic Néel phase.
 
-A clear way to probe these two phases is through the magnetic susceptibility $\chi$. Simulate an $8\times 8$ system over a range of temperatures for both cases and compare the results. For decoupled ladders the susceptibility exhibits activated behaviour at low temperature due to the spin gap; on the square lattice it tends to a finite constant as $T\to 0$. Note that on any finite system $\chi$ will eventually tend to zero at low enough temperature due to the finite-size gap, but this is not our focus here. Run the simulation on the command line with parameter file <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-08-quantum-phase-transition/parm8a" download>`parm8a`</a>:
+A clear way to probe these two phases is through the magnetic susceptibility $\chi$. Simulate an $8\times 8$ system over a range of temperatures for both cases and compare the results. For decoupled ladders the susceptibility exhibits activated behavior at low temperature due to the spin gap; on the square lattice it tends to a finite constant as $T\to 0$. Note that on any finite system $\chi$ will eventually tend to zero at low enough temperature due to the finite-size gap, but this is not our focus here. Run the simulation on the command line with parameter file <a href="https://github.com/ALPSim/ALPS/blob/master/tutorials/mc-08-quantum-phase-transition/parm8a" download>`parm8a`</a>:
 
 ```
 parameter2xml parm8a
@@ -96,7 +96,7 @@ input_file = pyalps.writeInputFiles('parm8a',parms)
 pyalps.runApplication('loop',input_file)
 ```
     
-For $J_2=0$, the value of the spin gap can be estimated from the finite-$T$ behaviour of the magnetic susceptibility (derived in Phys. Rev. B 50, 13515 (1994)):
+For $J_2=0$, the value of the spin gap can be estimated from the finite-$T$ behavior of the magnetic susceptibility (derived in Phys. Rev. B 50, 13515 (1994)):
 
 $$\chi = \frac{A}{\sqrt{T}} \exp\!\left(-\frac{\Delta}{T}\right),$$
 
@@ -140,7 +140,7 @@ For $J_2=1$ the susceptibility should approach a finite constant as $T \to 0$, r
 
 ## Locate the phase transition
 
-Having identified two different phases at $J_2=0$ and $J_2=1$, there must be (at least) one quantum phase transition separating them. The background run started above scans the coupling range $J_2 \in [0.2,0.4]$ for system sizes $L=8,10,12,16$ at an inverse temperature $\beta=2L$ (see `parm8b` / `tutorial8b.py` for the full parameter set). Once it has finished, load and analyse the results as described below.
+Having identified two different phases at $J_2=0$ and $J_2=1$, there must be (at least) one quantum phase transition separating them. The background run started above scans the coupling range $J_2 \in [0.2,0.4]$ for system sizes $L=8,10,12,16$ at an inverse temperature $\beta=2L$ (see `parm8b` / `tutorial8b.py` for the full parameter set). Once it has finished, load and analyze the results as described below.
 
 ### Choice of inverse temperature
 
@@ -277,7 +277,7 @@ This second transition belongs to the same universality class as the first — t
 
 ## Questions
 
-- Plot the magnetic susceptibility for $J_2=0$ and $J_2=1$. How do the low-temperature behaviours differ, and what does each tell you about the ground state?
+- Plot the magnetic susceptibility for $J_2=0$ and $J_2=1$. How do the low-temperature behaviors differ, and what does each tell you about the ground state?
 - For $J_2=0$, fit $\chi$ to $A/\sqrt{T}\exp(-\Delta/T)$ and extract the spin gap $\Delta$. How does your estimate compare with values from the literature (Phys. Rev. Lett. 73, 886 (1994); Phys. Rev. Lett. 77, 1865 (1996))?
 - From the crossings of the $\rho_s L$ and Binder cumulant curves, what is your estimate of the first quantum critical point $J_2^c$?
 - Change $\beta=2L$ to $\beta=4L$ and repeat. Are the stiffness and Binder cumulant affected? Now try $\beta=L/4$: do the results change noticeably? What does this tell you about the role of temperature in these simulations?


### PR DESCRIPTION
## Summary
- Replaces British English spellings (behaviour, colour, analyse, organise, neighbour, magnetisation, etc.) with American English equivalents (behavior, color, analyze, organize, neighbor, magnetization, etc.) across all English-language tutorial pages under `content/en/tutorials/`
- Scoped to `content/en/` only — `zh-cn/` and `ja/` are untouched

## Test plan
- [x] Verified no remaining British spellings via grep sweep
- [x] `hugo --gc --minify` builds cleanly with no new errors/warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)