### PR TITLE
Fix broken Cite button link on landing page

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -33,7 +33,7 @@ Since its inception, ALPS has been used by hundreds of researchers across at lea
 {{< cta-button text="FAQ" link="faqs" icon="help" >}}
 {{< cta-button text="Papers" link="documentation/pubs/" icon="library_books" >}}
 {{< cta-button text="Publication Link" link="https://iopscience.iop.org/article/10.1088/1742-5468/2011/05/P05001" icon="article" >}}
-{{< cta-button text="Cite" link="/data/bauer2011.bib" icon="format_quote" >}}
+{{< cta-button text="Cite" link="documentation/pubs/" icon="format_quote" >}}
 </div>
 
 ### Tutorials

--- a/content/ja/_index.md
+++ b/content/ja/_index.md
@@ -33,7 +33,7 @@ ALPS（Algorithms and Libraries for Physics Simulations）は、量子および�
 {{< cta-button text="よくある質問" link="faqs" icon="help" >}}
 {{< cta-button text="論文" link="documentation/pubs/" icon="library_books" >}}
 {{< cta-button text="論文リンク" link="https://iopscience.iop.org/article/10.1088/1742-5468/2011/05/P05001" icon="article" >}}
-{{< cta-button text="引用" link="/data/bauer2011.bib" icon="format_quote" >}}
+{{< cta-button text="引用" link="documentation/pubs/" icon="format_quote" >}}
 </div>
 
 ### チュートリアル

--- a/content/zh-cn/_index.md
+++ b/content/zh-cn/_index.md
@@ -33,7 +33,7 @@ ALPS（物理模拟算法与程序库）是一款面向量子和经典凝聚态�
 {{< cta-button text="常见问题" link="faqs" icon="help" >}}
 {{< cta-button text="论文" link="documentation/pubs/" icon="library_books" >}}
 {{< cta-button text="论文链接" link="https://iopscience.iop.org/article/10.1088/1742-5468/2011/05/P05001" icon="article" >}}
-{{< cta-button text="引用" link="/data/bauer2011.bib" icon="format_quote" >}}
+{{< cta-button text="引用" link="documentation/pubs/" icon="format_quote" >}}
 </div>
 
 ### 教程


### PR DESCRIPTION
## Summary
- The "Cite" CTA button on the homepage linked directly to `/data/bauer2011.bib`; point it to the Papers documentation page (`documentation/pubs/`) instead, across en/zh-cn/ja.

## Test plan
- [x] `hugo --gc` builds cleanly across en/zh-cn/ja with no errors
- [ ] Manual click-through of the "Cite" button on the homepage in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)